### PR TITLE
api: add skipBackgroundRequests support for MutatingPolicy and GeneratingPolicy

### DIFF
--- a/api/policies.kyverno.io/v1beta1/generating_policy.go
+++ b/api/policies.kyverno.io/v1beta1/generating_policy.go
@@ -261,6 +261,16 @@ func (s GeneratingPolicySpec) AdmissionEnabled() bool {
 	return *s.EvaluationConfiguration.Admission.Enabled
 }
 
+// SkipBackgroundRequestsEnabled returns whether background requests should be skipped.
+// Returns true by default.
+func (s GeneratingPolicySpec) SkipBackgroundRequestsEnabled() bool {
+	const defaultValue = true
+	if s.EvaluationConfiguration == nil || s.EvaluationConfiguration.SkipBackgroundRequests == nil {
+		return defaultValue
+	}
+	return *s.EvaluationConfiguration.SkipBackgroundRequests
+}
+
 type GeneratingPolicyEvaluationConfiguration struct {
 	// Admission controls policy evaluation during admission.
 	// +optional
@@ -276,6 +286,13 @@ type GeneratingPolicyEvaluationConfiguration struct {
 
 	// OrphanDownstreamOnPolicyDelete defines the configuration for orphaning downstream resources on policy delete.
 	OrphanDownstreamOnPolicyDelete *OrphanDownstreamOnPolicyDeleteConfiguration `json:"orphanDownstreamOnPolicyDelete,omitempty"`
+
+	// SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+	// The default value is set to "true", it must be set to "false" to apply
+	// generate rules to those requests.
+	// +kubebuilder:default=true
+	// +kubebuilder:validation:Optional
+	SkipBackgroundRequests *bool `json:"skipBackgroundRequests,omitempty"`
 }
 
 // GenerateExistingConfiguration defines the configuration for generating resources for existing triggers.

--- a/api/policies.kyverno.io/v1beta1/mutating_policy.go
+++ b/api/policies.kyverno.io/v1beta1/mutating_policy.go
@@ -404,6 +404,16 @@ func (s MutatingPolicySpec) MutateExistingEnabled() bool {
 	return *s.EvaluationConfiguration.MutateExistingConfiguration.Enabled
 }
 
+// SkipBackgroundRequestsEnabled returns whether background requests should be skipped.
+// Returns true by default.
+func (s MutatingPolicySpec) SkipBackgroundRequestsEnabled() bool {
+	const defaultValue = true
+	if s.EvaluationConfiguration == nil || s.EvaluationConfiguration.SkipBackgroundRequests == nil {
+		return defaultValue
+	}
+	return *s.EvaluationConfiguration.SkipBackgroundRequests
+}
+
 type MutatingPolicyEvaluationConfiguration struct {
 	// Mode is the mode of policy evaluation.
 	// Allowed values are "Kubernetes" or "JSON".
@@ -422,6 +432,13 @@ type MutatingPolicyEvaluationConfiguration struct {
 	// MutateExisting controls whether existing resources are mutated.
 	// +optional
 	MutateExistingConfiguration *MutateExistingConfiguration `json:"mutateExisting,omitempty"`
+
+	// SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+	// The default value is set to "true", it must be set to "false" to apply
+	// mutateExisting rules to those requests.
+	// +kubebuilder:default=true
+	// +kubebuilder:validation:Optional
+	SkipBackgroundRequests *bool `json:"skipBackgroundRequests,omitempty"`
 }
 
 type MutatingPolicyAutogenConfiguration struct {

--- a/api/policies.kyverno.io/v1beta1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1beta1/zz_generated.deepcopy.go
@@ -485,6 +485,11 @@ func (in *GeneratingPolicyEvaluationConfiguration) DeepCopyInto(out *GeneratingP
 		*out = new(OrphanDownstreamOnPolicyDeleteConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SkipBackgroundRequests != nil {
+		in, out := &in.SkipBackgroundRequests, &out.SkipBackgroundRequests
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -1120,6 +1125,11 @@ func (in *MutatingPolicyEvaluationConfiguration) DeepCopyInto(out *MutatingPolic
 		in, out := &in.MutateExistingConfiguration, &out.MutateExistingConfiguration
 		*out = new(MutateExistingConfiguration)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.SkipBackgroundRequests != nil {
+		in, out := &in.SkipBackgroundRequests, &out.SkipBackgroundRequests
+		*out = new(bool)
+		**out = **in
 	}
 	return
 }

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -1318,6 +1318,13 @@ spec:
                           Optional. Defaults to "false" if not specified.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      generate rules to those requests.
+                    type: boolean
                   synchronize:
                     description: Synchronization defines the configuration for the
                       synchronization of generated resources.

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -4453,6 +4453,13 @@ spec:
                           When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      mutateExisting rules to those requests.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -5465,6 +5472,13 @@ spec:
                                         When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                                       type: boolean
                                   type: object
+                                skipBackgroundRequests:
+                                  default: true
+                                  description: |-
+                                    SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                                    The default value is set to "true", it must be set to "false" to apply
+                                    mutateExisting rules to those requests.
+                                  type: boolean
                               type: object
                             failurePolicy:
                               description: |-

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -706,6 +706,13 @@ spec:
                           Optional. Defaults to "false" if not specified.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      generate rules to those requests.
+                    type: boolean
                   synchronize:
                     description: Synchronization defines the configuration for the
                       synchronization of generated resources.

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -2305,6 +2305,13 @@ spec:
                           When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      mutateExisting rules to those requests.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -3317,6 +3324,13 @@ spec:
                                         When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                                       type: boolean
                                   type: object
+                                skipBackgroundRequests:
+                                  default: true
+                                  description: |-
+                                    SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                                    The default value is set to "true", it must be set to "false" to apply
+                                    mutateExisting rules to those requests.
+                                  type: boolean
                               type: object
                             failurePolicy:
                               description: |-

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -2993,6 +2993,13 @@ spec:
                           Optional. Defaults to "false" if not specified.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      generate rules to those requests.
+                    type: boolean
                   synchronize:
                     description: Synchronization defines the configuration for the
                       synchronization of generated resources.
@@ -14897,6 +14904,13 @@ spec:
                           When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      mutateExisting rules to those requests.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -15909,6 +15923,13 @@ spec:
                                         When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                                       type: boolean
                                   type: object
+                                skipBackgroundRequests:
+                                  default: true
+                                  description: |-
+                                    SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                                    The default value is set to "true", it must be set to "false" to apply
+                                    mutateExisting rules to those requests.
+                                  type: boolean
                               type: object
                             failurePolicy:
                               description: |-
@@ -18814,6 +18835,13 @@ spec:
                           Optional. Defaults to "false" if not specified.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      generate rules to those requests.
+                    type: boolean
                   synchronize:
                     description: Synchronization defines the configuration for the
                       synchronization of generated resources.
@@ -26275,6 +26303,13 @@ spec:
                           When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      mutateExisting rules to those requests.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -27287,6 +27322,13 @@ spec:
                                         When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                                       type: boolean
                                   type: object
+                                skipBackgroundRequests:
+                                  default: true
+                                  description: |-
+                                    SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                                    The default value is set to "true", it must be set to "false" to apply
+                                    mutateExisting rules to those requests.
+                                  type: boolean
                               type: object
                             failurePolicy:
                               description: |-

--- a/config/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -1316,6 +1316,13 @@ spec:
                           Optional. Defaults to "false" if not specified.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      generate rules to those requests.
+                    type: boolean
                   synchronize:
                     description: Synchronization defines the configuration for the
                       synchronization of generated resources.

--- a/config/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -4451,6 +4451,13 @@ spec:
                           When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      mutateExisting rules to those requests.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -5463,6 +5470,13 @@ spec:
                                         When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                                       type: boolean
                                   type: object
+                                skipBackgroundRequests:
+                                  default: true
+                                  description: |-
+                                    SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                                    The default value is set to "true", it must be set to "false" to apply
+                                    mutateExisting rules to those requests.
+                                  type: boolean
                               type: object
                             failurePolicy:
                               description: |-

--- a/config/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -704,6 +704,13 @@ spec:
                           Optional. Defaults to "false" if not specified.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      generate rules to those requests.
+                    type: boolean
                   synchronize:
                     description: Synchronization defines the configuration for the
                       synchronization of generated resources.

--- a/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -2303,6 +2303,13 @@ spec:
                           When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                         type: boolean
                     type: object
+                  skipBackgroundRequests:
+                    default: true
+                    description: |-
+                      SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                      The default value is set to "true", it must be set to "false" to apply
+                      mutateExisting rules to those requests.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -3315,6 +3322,13 @@ spec:
                                         When spec.targetMatchConstraints is not defined, Kyverno mutates existing resources matched in spec.matchConstraints.
                                       type: boolean
                                   type: object
+                                skipBackgroundRequests:
+                                  default: true
+                                  description: |-
+                                    SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+                                    The default value is set to "true", it must be set to "false" to apply
+                                    mutateExisting rules to those requests.
+                                  type: boolean
                               type: object
                             failurePolicy:
                               description: |-

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -13958,6 +13958,19 @@ OrphanDownstreamOnPolicyDeleteConfiguration
 <p>OrphanDownstreamOnPolicyDelete defines the configuration for orphaning downstream resources on policy delete.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>skipBackgroundRequests</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+The default value is set to &ldquo;true&rdquo;, it must be set to &ldquo;false&rdquo; to apply
+generate rules to those requests.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />
@@ -15147,6 +15160,19 @@ MutateExistingConfiguration
 <td>
 <em>(Optional)</em>
 <p>MutateExisting controls whether existing resources are mutated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>skipBackgroundRequests</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+The default value is set to &ldquo;true&rdquo;, it must be set to &ldquo;false&rdquo; to apply
+mutateExisting rules to those requests.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/user/crd/kyverno_cel_policies.v1beta1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1beta1.html
@@ -6517,6 +6517,37 @@ Optional. Defaults to &quot;false&quot; if not specified.</p>
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>skipBackgroundRequests</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+The default value is set to &quot;true&quot;, it must be set to &quot;false&quot; to apply
+generate rules to those requests.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>
@@ -8908,6 +8939,37 @@ Optional. Default value is &quot;Kubernetes&quot;.</p>
           
 
           <p>MutateExisting controls whether existing resources are mutated.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>skipBackgroundRequests</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
+The default value is set to &quot;true&quot;, it must be set to &quot;false&quot; to apply
+mutateExisting rules to those requests.</p>
 
 
           


### PR DESCRIPTION
### Summary

This PR adds support for `skipBackgroundRequests` to MutatingPolicy and
GeneratingPolicy so they behave the same way as ClusterPolicy.

### What I changed

- Added an optional `skipBackgroundRequests` field to the evaluation
  configuration for both policy types
- Added helper methods to resolve the effective value safely, defaulting
  to `true`
- Regenerated CRDs, Helm charts, and API docs to include the new field

### Why this change

Right now, `skipBackgroundRequests` is available for ClusterPolicy, but not for
MutatingPolicy or GeneratingPolicy. This makes it hard to use features like
`mutateExisting` or `generateExisting` with background requests in a consistent
way.

With this change, users can explicitly set `skipBackgroundRequests: false` when
they want background controller requests to be processed, while keeping the
existing default behavior unchanged.

### Backward compatibility

This is fully backward compatible. Policies that don’t specify the field will
continue to skip background requests by default.

### Related issue
- kyverno/kyverno#14852
