### PR TITLE
feat: add useServerSideApply to GeneratingPolicy spec

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/generating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/generating_policy.go
@@ -81,6 +81,12 @@ type GeneratingPolicySpec struct {
 	// +optional
 	WebhookConfiguration *WebhookConfiguration `json:"webhookConfiguration,omitempty"`
 
+	// UseServerSideApply controls whether to use server-side apply for generate rules.
+	// If set to true, generated resources will use SSA instead of create/update.
+	// Defaults to false.
+	// +optional
+	UseServerSideApply bool `json:"useServerSideApply,omitempty"`
+
 	// Generation defines a set of CEL expressions that will be evaluated to generate resources.
 	// Required.
 	// +kubebuilder:validation:MinItems=1

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -504,6 +504,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -1120,6 +1126,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -1735,6 +1747,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -506,6 +506,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -1123,6 +1129,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -2179,6 +2179,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -2795,6 +2801,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -3410,6 +3422,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -18653,6 +18671,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -19270,6 +19294,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.

--- a/config/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -502,6 +502,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -1118,6 +1124,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -1733,6 +1745,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.

--- a/config/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -504,6 +504,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
@@ -1121,6 +1127,12 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
                 x-kubernetes-map-type: atomic
+              useServerSideApply:
+                description: |-
+                  UseServerSideApply controls whether to use server-side apply for generate rules.
+                  If set to true, generated resources will use SSA instead of create/update.
+                  Defaults to false.
+                type: boolean
               variables:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -353,6 +353,20 @@ WebhookConfiguration
 </tr>
 <tr>
 <td>
+<code>useServerSideApply</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>generate</code><br/>
 <em>
 <a href="#policies.kyverno.io/v1alpha1.Generation">
@@ -2460,6 +2474,20 @@ WebhookConfiguration
 </tr>
 <tr>
 <td>
+<code>useServerSideApply</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>generate</code><br/>
 <em>
 <a href="#policies.kyverno.io/v1alpha1.Generation">
@@ -2805,6 +2833,20 @@ WebhookConfiguration
 <td>
 <em>(Optional)</em>
 <p>WebhookConfiguration defines the configuration for the webhook.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>useServerSideApply</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
 </td>
 </tr>
 <tr>
@@ -4807,6 +4849,20 @@ WebhookConfiguration
 <td>
 <em>(Optional)</em>
 <p>WebhookConfiguration defines the configuration for the webhook.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>useServerSideApply</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
 </td>
 </tr>
 <tr>
@@ -7661,6 +7717,20 @@ WebhookConfiguration
 </tr>
 <tr>
 <td>
+<code>useServerSideApply</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>generate</code><br/>
 <em>
 <a href="#policies.kyverno.io/v1alpha1.Generation">
@@ -9764,6 +9834,20 @@ WebhookConfiguration
 <td>
 <em>(Optional)</em>
 <p>WebhookConfiguration defines the configuration for the webhook.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>useServerSideApply</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -748,6 +748,35 @@ Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
     
     
       <tr>
+        <td><code>useServerSideApply</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
         <td><code>generate</code>
           
           <span style="color:blue;"> *</span>
@@ -5244,6 +5273,35 @@ Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
           
 
           <p>WebhookConfiguration defines the configuration for the webhook.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>useServerSideApply</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>UseServerSideApply controls whether to use server-side apply for generate rules.
+If set to true, generated resources will use SSA instead of create/update.
+Defaults to false.</p>
 
 
           


### PR DESCRIPTION
## Explanation

This PR adds a new optional field `spec.useServerSideApply` to GeneratingPolicy and NamespacedGeneratingPolicy in the API. This field allows users to opt into Server-Side Apply (SSA) for generated resources in future controller logic, aligning GeneratingPolicy with existing behavior available in Policy and ClusterPolicy. This is an additive API change and does not modify existing behavior since the field defaults to false, ensuring full backward compatibility.

## Related issue

Fixes kyverno/kyverno#14853  
Refs kyverno/kyverno#15079  
@eddycharly

## Proposed Changes

- Add `useServerSideApply` boolean field to the shared GeneratingPolicySpec (v1alpha1)
- Ensure v1beta1 and v1 automatically reuse the updated spec through shared types
- Regenerate CRDs and OpenAPI schemas using `make codegen`
- Keep the field optional with default `false` to preserve existing behavior
- No runtime logic changes in this PR (API-only change to support follow-up controller implementation)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

This PR is intentionally scoped to the API layer only by introducing the `useServerSideApply` field and regenerating the CRDs. The actual wiring and usage of this field in the engine and controllers is handled in the kyverno/kyverno follow-up PR https://github.com/kyverno/kyverno/pull/15079 , keeping API evolution separate from runtime implementation as per project conventions.