### PR TITLE
fix: add explicit conversion.strategy to CRDs to prevent ArgoCD drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,7 @@ helm-chart: controller-gen
 	@$(SED) -i '/^  annotations:/i \ \ labels:' charts/kyverno-api/templates/crds/*
 	@$(SED) -i '/^  labels:/a \ \ \ \ {{- include "kyverno-api.labels" . | nindent 4 }}' charts/kyverno-api/templates/crds/*
 	@$(SED) -i '/controller-gen.kubebuilder.io/d' charts/kyverno-api/templates/crds/*
+	@$(SED) -i '/^spec:/a \ \ conversion:\n\ \ \ \ strategy: None' charts/kyverno-api/templates/crds/*
 
 .PHONY: helm-docs
 helm-docs: helm-chart $(HELM_DOCS) ## Generate helm docs

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_deletingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_deletingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: deletingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: generatingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: imagevalidatingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: mutatingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespaceddeletingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespaceddeletingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: namespaceddeletingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: namespacedgeneratingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: namespacedimagevalidatingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: namespacedmutatingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: namespacedvalidatingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: policyexceptions.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     kind: PolicyException

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_validatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_validatingpolicies.yaml
@@ -8,6 +8,8 @@ metadata:
     {{- include "kyverno-api.annotations" . | nindent 4 }}
   name: validatingpolicies.policies.kyverno.io
 spec:
+  conversion:
+    strategy: None
   group: policies.kyverno.io
   names:
     categories:


### PR DESCRIPTION
## Problem

When deploying Kyverno via ArgoCD + Helm, CRDs remain permanently OutOfSync after upgrading to chart version 3.7.x.

Kubernetes automatically injects `spec.conversion.strategy: None` when a CRD is applied without a `conversion` field. Since the chart templates do not include this field, ArgoCD detects a permanent diff between the desired state (no conversion field) and the live state (`conversion.strategy: None`).

This is particularly problematic when using ApplicationSet with RollingSync, as the OutOfSync state on phase-0 (kyverno) blocks progressive deployment of all subsequent phases.

## Fix

- Added `spec.conversion.strategy: None` to all CRD templates in `charts/kyverno-api/templates/crds/`
- Updated `Makefile` `helm-chart` target to inject the field during CRD generation

## Affected CRDs

All 11 CRDs under `policies.kyverno.io`:
- deletingpolicies, generatingpolicies, imagevalidatingpolicies, mutatingpolicies
- namespaceddeletingpolicies, namespacedgeneratingpolicies, namespacedimagevalidatingpolicies, namespacedmutatingpolicies, namespacedvalidatingpolicies
- policyexceptions, validatingpolicies

## Verification

Compared helm-rendered CRD (desired) vs live cluster object (stripping runtime fields). The only structural diff was the missing `spec.conversion` field.

Fixes kyverno/kyverno#15116