### PR TITLE
feat: Add support for additionalExtensions field in the API for cosign keyless signing

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/imagevalidating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/imagevalidating_policy.go
@@ -455,6 +455,9 @@ type Keyless struct {
 	// If not provided, the system roots are used.
 	// +kubebuilder:validation:Optional
 	Roots string `json:"roots,omitempty"`
+	// AdditionalExtensions are certificate-extensions used for keyless signing.
+	// +kubebuilder:validation:Optional
+	AdditionalExtensions map[string]string `json:"additionalExtensions,omitempty"`
 }
 
 // Certificate defines the configuration for local signature verification

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -929,6 +929,13 @@ func (in *Keyless) DeepCopyInto(out *Keyless) {
 		*out = make([]Identity, len(*in))
 		copy(*out, *in)
 	}
+	if in.AdditionalExtensions != nil {
+		in, out := &in.AdditionalExtensions, &out.AdditionalExtensions
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -211,6 +211,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -1284,6 +1290,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -2506,6 +2519,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -3579,6 +3598,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -4800,6 +4826,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -5873,6 +5905,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
@@ -211,6 +211,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -1284,6 +1290,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -2505,6 +2518,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -3578,6 +3597,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -3752,6 +3752,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -4825,6 +4831,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -6047,6 +6060,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -7120,6 +7139,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -8341,6 +8367,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -9414,6 +9446,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -19612,6 +19651,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -20685,6 +20730,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -21906,6 +21958,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -22979,6 +23037,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.

--- a/config/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -209,6 +209,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -1282,6 +1288,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -2504,6 +2517,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -3577,6 +3596,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -4798,6 +4824,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -5871,6 +5903,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.

--- a/config/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
@@ -209,6 +209,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -1282,6 +1288,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.
@@ -2503,6 +2516,12 @@ spec:
                           description: Keyless sets the configuration to verify the
                             authority against a Fulcio instance.
                           properties:
+                            additionalExtensions:
+                              additionalProperties:
+                                type: string
+                              description: AdditionalExtensions are certificate-extensions
+                                used for keyless signing.
+                              type: object
                             identities:
                               description: Identities sets a list of identities.
                               items:
@@ -3576,6 +3595,13 @@ spec:
                                           to verify the authority against a Fulcio
                                           instance.
                                         properties:
+                                          additionalExtensions:
+                                            additionalProperties:
+                                              type: string
+                                            description: AdditionalExtensions are
+                                              certificate-extensions used for keyless
+                                              signing.
+                                            type: object
                                           identities:
                                             description: Identities sets a list of
                                               identities.

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -5605,6 +5605,17 @@ string
 If not provided, the system roots are used.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>additionalExtensions</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<p>AdditionalExtensions are certificate-extensions used for keyless signing.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -6857,6 +6857,35 @@ If not provided, the system roots are used.</p>
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>additionalExtensions</code>
+          
+          <span style="color:blue;"> *</span>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>AdditionalExtensions are certificate-extensions used for keyless signing.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>


### PR DESCRIPTION
## Explanation

Add `additionalExtensions` field in ImageValidatingPolicy in order to support attestor in cosign keyless verification.

## Related issue

Needed for / Part of https://github.com/kyverno/kyverno/issues/15809


## Proposed Changes

Added the field in API to be used within the kyverno/kyverno repo


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments
