### PR TITLE
feat: Add validationActions field type to PolicyException to override vpol validationAction

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/policy_exception.go
+++ b/api/policies.kyverno.io/v1alpha1/policy_exception.go
@@ -93,6 +93,11 @@ type PolicyRef struct {
 
 	// Kind is the kind of the policy
 	Kind string `json:"kind"`
+
+	// ValidationAction overrides the policy's validation action when set
+	// +optional
+	// +kubebuilder:validation:Enum=Deny;Audit;Warn
+	ValidationAction admissionregistrationv1.ValidationAction `json:"validationAction,omitempty"`
 }
 
 func (p *PolicyRef) Validate(path *field.Path) (errs field.ErrorList) {

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
@@ -118,6 +118,14 @@ spec:
                     name:
                       description: Name is the name of the policy
                       type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
+                      type: string
                   required:
                   - kind
                   - name
@@ -253,6 +261,14 @@ spec:
                     name:
                       description: Name is the name of the policy
                       type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
+                      type: string
                   required:
                   - kind
                   - name
@@ -386,6 +402,14 @@ spec:
                       type: string
                     name:
                       description: Name is the name of the policy
+                      type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
                       type: string
                   required:
                   - kind

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -32083,6 +32083,14 @@ spec:
                     name:
                       description: Name is the name of the policy
                       type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
+                      type: string
                   required:
                   - kind
                   - name
@@ -32218,6 +32226,14 @@ spec:
                     name:
                       description: Name is the name of the policy
                       type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
+                      type: string
                   required:
                   - kind
                   - name
@@ -32351,6 +32367,14 @@ spec:
                       type: string
                     name:
                       description: Name is the name of the policy
+                      type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
                       type: string
                   required:
                   - kind

--- a/config/crds/policies.kyverno.io_policyexceptions.yaml
+++ b/config/crds/policies.kyverno.io_policyexceptions.yaml
@@ -116,6 +116,14 @@ spec:
                     name:
                       description: Name is the name of the policy
                       type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
+                      type: string
                   required:
                   - kind
                   - name
@@ -251,6 +259,14 @@ spec:
                     name:
                       description: Name is the name of the policy
                       type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
+                      type: string
                   required:
                   - kind
                   - name
@@ -384,6 +400,14 @@ spec:
                       type: string
                     name:
                       description: Name is the name of the policy
+                      type: string
+                    validationAction:
+                      description: ValidationAction overrides the policy's validation
+                        action when set
+                      enum:
+                      - Deny
+                      - Audit
+                      - Warn
                       type: string
                   required:
                   - kind

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -6696,6 +6696,20 @@ string
 <p>Kind is the kind of the policy</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>validationAction</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#validationaction-v1-admissionregistration">
+Kubernetes admissionregistration/v1.ValidationAction
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ValidationAction overrides the policy&rsquo;s validation action when set</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -8814,6 +8814,35 @@ For example:</p>
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>validationAction</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#validationaction-v1-admissionregistration">
+                <span style="font-family: monospace">admissionregistration/v1.ValidationAction</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>ValidationAction overrides the policy's validation action when set</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>


### PR DESCRIPTION
## Explanation

We need to support override for ValidatingPolicy `validationActions` in PolicyException so in order to do that we need to define the `validationAction` field first in PolicyException API

For the CEL version

## Related issue

Needed for: https://github.com/kyverno/kyverno/issues/14927 and its PR: https://github.com/kyverno/kyverno/pull/16481


## Proposed Changes

- Add `validationAction` field to PolicyException


## Checklist


- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments
