### PR TITLE
Add interval field to BackgroundConfiguration for per-policy background scan interval

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/common.go
+++ b/api/policies.kyverno.io/v1alpha1/common.go
@@ -1,5 +1,9 @@
 package v1alpha1
 
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 type EvaluationMode = string
 
 type EvaluationConfiguration struct {
@@ -33,4 +37,11 @@ type BackgroundConfiguration struct {
 	// +optional
 	// +kubebuilder:default=true
 	Enabled *bool `json:"enabled,omitempty"`
+
+	// Interval defines how often background scanning is performed for this specific policy.
+    // Overrides the global background scan interval set at the controller level.
+    // The value must be a valid duration string (e.g., "15m", "1h", "30s").
+    // Optional. If not set, the global background scan interval is used.
+    // +optional
+    Interval *metav1.Duration `json:"interval,omitempty"`
 }

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -110,6 +110,11 @@ func (in *BackgroundConfiguration) DeepCopyInto(out *BackgroundConfiguration) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Interval != nil {
+		in, out := &in.Interval, &out.Interval
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -503,6 +503,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1615,6 +1622,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2858,6 +2872,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3970,6 +3991,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -5212,6 +5240,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -6324,6 +6359,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -101,6 +101,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1113,6 +1120,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2288,6 +2302,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3300,6 +3321,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -4474,6 +4502,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -5486,6 +5521,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
@@ -503,6 +503,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1615,6 +1622,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2857,6 +2871,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3969,6 +3990,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -101,6 +101,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1113,6 +1120,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2287,6 +2301,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3299,6 +3320,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
@@ -153,6 +153,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -860,6 +867,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -1715,6 +1729,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -2422,6 +2443,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_validatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_validatingpolicies.yaml
@@ -153,6 +153,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -860,6 +867,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -1716,6 +1730,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -2423,6 +2444,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -3278,6 +3306,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3985,6 +4020,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -4044,6 +4044,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -5156,6 +5163,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -6399,6 +6413,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -7511,6 +7532,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -8753,6 +8781,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -9865,6 +9900,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -10725,6 +10767,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -11737,6 +11786,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -12912,6 +12968,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -13924,6 +13987,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -15098,6 +15168,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -16110,6 +16187,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -20084,6 +20168,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -21196,6 +21287,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -22438,6 +22536,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -23550,6 +23655,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -24410,6 +24522,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -25422,6 +25541,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -26596,6 +26722,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -27608,6 +27741,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -28854,6 +28994,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -29561,6 +29708,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -30416,6 +30570,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -31123,6 +31284,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -32366,6 +32534,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -33073,6 +33248,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -33929,6 +34111,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -34636,6 +34825,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -35491,6 +35687,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -36198,6 +36401,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/config/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -501,6 +501,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1613,6 +1620,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2856,6 +2870,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3968,6 +3989,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -5210,6 +5238,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -6322,6 +6357,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/config/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -99,6 +99,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1111,6 +1118,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2286,6 +2300,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3298,6 +3319,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -4472,6 +4500,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -5484,6 +5519,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/config/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
@@ -501,6 +501,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1613,6 +1620,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2855,6 +2869,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3967,6 +3988,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -99,6 +99,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -1111,6 +1118,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -2285,6 +2299,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3297,6 +3318,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/config/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
@@ -151,6 +151,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -858,6 +865,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -1713,6 +1727,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -2420,6 +2441,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/config/crds/policies.kyverno.io_validatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_validatingpolicies.yaml
@@ -151,6 +151,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -858,6 +865,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -1714,6 +1728,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -2421,6 +2442,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-
@@ -3276,6 +3304,13 @@ spec:
                           Optional. Default value is "true". The value must be set to "false" if the policy rule
                           uses variables that are only available in the admission review request (e.g. user name).
                         type: boolean
+                      interval:
+                        description: |-
+                          Interval defines how often background scanning is performed for this specific policy.
+                          Overrides the global background scan interval set at the controller level.
+                          The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                          Optional. If not set, the global background scan interval is used.
+                        type: string
                     type: object
                   mode:
                     description: |-
@@ -3983,6 +4018,13 @@ spec:
                                         Optional. Default value is "true". The value must be set to "false" if the policy rule
                                         uses variables that are only available in the admission review request (e.g. user name).
                                       type: boolean
+                                    interval:
+                                      description: |-
+                                        Interval defines how often background scanning is performed for this specific policy.
+                                        Overrides the global background scan interval set at the controller level.
+                                        The value must be a valid duration string (e.g., "15m", "1h", "30s").
+                                        Optional. If not set, the global background scan interval is used.
+                                      type: string
                                   type: object
                                 mode:
                                   description: |-

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -4007,6 +4007,23 @@ Optional. Default value is &ldquo;true&rdquo;. The value must be set to &ldquo;f
 uses variables that are only available in the admission review request (e.g. user name).</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>interval</code><br/>
+<em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+Kubernetes meta/v1.Duration
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Interval defines how often background scanning is performed for this specific policy.
+Overrides the global background scan interval set at the controller level.
+The value must be a valid duration string (e.g., &ldquo;15m&rdquo;, &ldquo;1h&rdquo;, &ldquo;30s&rdquo;).
+Optional. If not set, the global background scan interval is used.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -3632,6 +3632,38 @@ uses variables that are only available in the admission review request (e.g. use
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>interval</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#Duration">
+                <span style="font-family: monospace">meta/v1.Duration</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>Interval defines how often background scanning is performed for this specific policy.
+Overrides the global background scan interval set at the controller level.
+The value must be a valid duration string (e.g., &quot;15m&quot;, &quot;1h&quot;, &quot;30s&quot;).
+Optional. If not set, the global background scan interval is used.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>


### PR DESCRIPTION

## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

This PR adds an interval field to the BackgroundConfiguration struct in the Kyverno API. Currently, background scanning in Kyverno runs on a single global interval configured at the controller level, meaning all policies are scanned at the same frequency regardless of their individual needs. This addition allows users to override the global background scan interval on a per-policy basis by setting spec.evaluation.background.interval on ValidatingPolicy, MutatingPolicy, and other CEL-based policy types. This is an addition of new API behavior.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Fixes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@eddycharly`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [kyverno Slack Channel](https://kubernetes.slack.com/).
-->
Part of kyverno/KDP#89 ,   Per-Policy Background Scan Interval proposal, discussed and approved by maintainers.


## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

**nNOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.

-->
After this change, users can configure per-policy background scan intervals like:

```
apiVersion: policies.kyverno.io/v1
kind: ValidatingPolicy
metadata:
  name: require-pod-labels
spec:
  evaluation:
    background:
      enabled: true
      interval: 15m   # this policy scans every 15 minutes
```

If interval is not set, the policy falls back to the global background scan interval as before , fully backward compatible.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

This PR covers only the API type change. A follow-up PR in `kyverno/kyverno` will implement the actual background controller behavior  reading` spec.evaluation.background.interval` per policy and scheduling scans accordingly, along with annotation support for Kubernetes-native `ValidatingAdmissionPolicy` and `MutatingAdmissionPolicy` types as agreed in the KDP discussion.

Signed-off-by:Varsha U N <varshaun58@gmail.com>

cc: @aerosouund @JimBugwadia @realshuting 