### PR TITLE
fix: add standard labels to CRDs

### DIFF
--- a/charts/kyverno-api/Chart.yaml
+++ b/charts/kyverno-api/Chart.yaml
@@ -1,3 +1,4 @@
 apiVersion: v2
 name: kyverno-api
 version: v0.0.0
+appVersion: v0.0.0

--- a/charts/kyverno-api/templates/_helpers.tpl
+++ b/charts/kyverno-api/templates/_helpers.tpl
@@ -5,14 +5,27 @@
 {{- end -}}
 
 {{- define "kyverno-api.labels" -}}
-helm.sh/chart: crds-{{ include "kyverno-api.chartVersion" . }}
+{{- $customLabels := .Values.labels | default dict -}}
+{{- if not (hasKey $customLabels "helm.sh/chart") }}
+helm.sh/chart: {{ .Chart.Name }}-{{ include "kyverno-api.chartVersion" . }}
+{{- end }}
+{{- if not (hasKey $customLabels "app.kubernetes.io/component") }}
 app.kubernetes.io/component: kyverno-api
+{{- end }}
+{{- if not (hasKey $customLabels "app.kubernetes.io/instance") }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+{{- if not (hasKey $customLabels "app.kubernetes.io/managed-by") }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+{{- if not (hasKey $customLabels "app.kubernetes.io/part-of") }}
 app.kubernetes.io/part-of: kyverno-api
+{{- end }}
+{{- if not (hasKey $customLabels "app.kubernetes.io/version") }}
 app.kubernetes.io/version: {{ include "kyverno-api.chartVersion" . }}
+{{- end }}
 {{- with .Values.labels }}
-{{ tpl (toYaml .) $ }}
+{{- tpl (toYaml .) $ -}}
 {{- end }}
 {{- end -}}
 

--- a/charts/kyverno-api/templates/_helpers.tpl
+++ b/charts/kyverno-api/templates/_helpers.tpl
@@ -22,7 +22,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: kyverno-api
 {{- end }}
 {{- if not (hasKey $customLabels "app.kubernetes.io/version") }}
-app.kubernetes.io/version: {{ include "kyverno-api.chartVersion" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 {{- with .Values.labels }}
 {{- tpl (toYaml .) $ -}}

--- a/charts/kyverno-api/templates/_helpers.tpl
+++ b/charts/kyverno-api/templates/_helpers.tpl
@@ -5,7 +5,15 @@
 {{- end -}}
 
 {{- define "kyverno-api.labels" -}}
-{{- tpl (toYaml .Values.labels) . -}}
+helm.sh/chart: crds-{{ include "kyverno-api.chartVersion" . }}
+app.kubernetes.io/component: kyverno-api
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: kyverno-api
+app.kubernetes.io/version: {{ include "kyverno-api.chartVersion" . }}
+{{- with .Values.labels }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
 {{- end -}}
 
 {{- define "kyverno-api.annotations" -}}


### PR DESCRIPTION
## Explanation

This PR fixes an issue where CRDs generated by the kyverno-api Helm chart were rendered without standard Helm/Kubernetes labels when no custom labels were provided.

It adds the standard labels used across other Kyverno Helm charts while preserving support for user-defined labels through `.Values.labels`.

## Label versioning

- `helm.sh/chart` uses `.Chart.Version` and tracks the Helm chart package version.
- `app.kubernetes.io/version` uses `.Chart.AppVersion` and tracks the kyverno-api release version.

This keeps the labels aligned with standard Helm conventions and allows the kyverno-api application version to be managed independently from the Helm chart package version.

`appVersion` has been added to `Chart.yaml` so the application version is explicitly defined and updated with kyverno-api releases.

## Related issue
Fixes #71


## Proposed Changes

- Add standard Helm/Kubernetes labels to the `kyverno-api.labels` helper.
- Use `.Chart.AppVersion` for `app.kubernetes.io/version` so it reflects the kyverno-api release version.
- Add `appVersion` to `Chart.yaml`.
- Preserve existing `.Values.labels` support for custom labels.
- Ensure all generated CRDs receive consistent metadata labels.


## Verification

Validated chart rendering with:

```bash
helm template test-release charts/kyverno-api
```

and linting with:

```bash
helm lint charts/kyverno-api
```

Verified that generated CRDs include the expected standard labels:

```yaml
metadata:
  labels:
    helm.sh/chart: kyverno-api-v0.0.0
    app.kubernetes.io/component: kyverno-api
    app.kubernetes.io/instance: test-release
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: kyverno-api
    app.kubernetes.io/version: "v0.0.0"
```

Also verified that custom labels provided through `.Values.labels` continue to be preserved.

Validated released chart metadata behavior by packaging the chart with a release version:

```bash
helm package charts/kyverno-api \
  --version 0.0.1-alpha.3 \
  --app-version v0.0.1-alpha.3
```

Rendered output confirms:

```yaml
helm.sh/chart: kyverno-api-0.0.1-alpha.3
app.kubernetes.io/version: "v0.0.1-alpha.3"
```
## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments
N/A