### PR TITLE
feat: add PolicyException properties and expiresAt updates

### DIFF
--- a/api/policies.kyverno.io/v1/policy_exception.go
+++ b/api/policies.kyverno.io/v1/policy_exception.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"time"
+
 	"github.com/kyverno/api/api/policies.kyverno.io/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,6 +23,14 @@ type PolicyException struct {
 
 	// Spec declares policy exception behaviors.
 	Spec PolicyExceptionSpec `json:"spec"`
+}
+
+// IsExpired checks if the policy exception has expired based on the expiresAt field.
+func (p *PolicyException) IsExpired() bool {
+	if p.Spec.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(p.Spec.ExpiresAt.Time)
 }
 
 // +kubebuilder:object:root=true

--- a/api/policies.kyverno.io/v1alpha1/policy_exception.go
+++ b/api/policies.kyverno.io/v1alpha1/policy_exception.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"time"
+
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -18,6 +20,14 @@ type PolicyException struct {
 
 	// Spec declares policy exception behaviors.
 	Spec PolicyExceptionSpec `json:"spec"`
+}
+
+// IsExpired checks if the policy exception has expired based on the expiresAt field.
+func (p *PolicyException) IsExpired() bool {
+	if p.Spec.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(p.Spec.ExpiresAt.Time)
 }
 
 // PolicyExceptionSpec stores policy exception spec
@@ -45,6 +55,20 @@ type PolicyExceptionSpec struct {
 	// +kubebuilder:validation:Enum=skip;pass
 	// +kubebuilder:default=skip
 	ReportResult string `json:"reportResult,omitempty"`
+
+	// ExpiresAt specifies the time when the policy exception expires.
+	// Once expired, the exception will no longer be applied to incoming requests.
+	// The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+	// +optional
+	ExpiresAt *metav1.Time `json:"expiresAt,omitempty"`
+
+	// Properties is an optional map for additional metadata attached to this exception.
+	// For example:
+	// - reason: why this exception is needed
+	// - ticket: external approval/request identifier
+	// - approved-by: comma-separated approver list
+	// +optional
+	Properties map[string]string `json:"properties,omitempty"`
 
 	// Evaluation mode denotes which controller is in charge of compiling and handling this exception.
 	// +optional

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -1427,6 +1427,17 @@ func (in *PolicyExceptionSpec) DeepCopyInto(out *PolicyExceptionSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.ExpiresAt != nil {
+		in, out := &in.ExpiresAt, &out.ExpiresAt
+		*out = (*in).DeepCopy()
+	}
+	if in.Properties != nil {
+		in, out := &in.Properties, &out.Properties
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/api/policies.kyverno.io/v1beta1/policy_exception.go
+++ b/api/policies.kyverno.io/v1beta1/policy_exception.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"time"
+
 	"github.com/kyverno/api/api/policies.kyverno.io/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -27,6 +29,14 @@ type PolicyException struct {
 
 func (p *PolicyException) GetKind() string {
 	return "PolicyException"
+}
+
+// IsExpired checks if the policy exception has expired based on the expiresAt field.
+func (p *PolicyException) IsExpired() bool {
+	if p.Spec.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(p.Spec.ExpiresAt.Time)
 }
 
 // Validate implements programmatic validation

--- a/api/policies.kyverno.io/v1beta1/policy_exception_test.go
+++ b/api/policies.kyverno.io/v1beta1/policy_exception_test.go
@@ -2,6 +2,7 @@ package v1beta1
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -98,4 +99,63 @@ func TestCELPolicyExceptionSpec_Validate(t *testing.T) {
 			assert.Equal(t, tt.wantErrs, gotErrs)
 		})
 	}
+}
+
+func TestCELPolicyException_IsExpired(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   *PolicyException
+		expected bool
+	}{
+		{
+			name: "expiresAt not set",
+			policy: &PolicyException{
+				Spec: PolicyExceptionSpec{},
+			},
+			expected: false,
+		},
+		{
+			name: "expiresAt in future",
+			policy: &PolicyException{
+				Spec: PolicyExceptionSpec{
+					ExpiresAt: &v1.Time{Time: time.Now().Add(1 * time.Hour)},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "expiresAt in past",
+			policy: &PolicyException{
+				Spec: PolicyExceptionSpec{
+					ExpiresAt: &v1.Time{Time: time.Now().Add(-1 * time.Hour)},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.policy.IsExpired())
+		})
+	}
+}
+
+func TestCELPolicyExceptionSpec_Properties(t *testing.T) {
+	policy := &PolicyException{
+		Spec: PolicyExceptionSpec{
+			PolicyRefs: []PolicyRef{{
+				Name: "foo",
+				Kind: "Foo",
+			}},
+			Properties: map[string]string{
+				"reason":      "temporary exception",
+				"approved-by": "alice,bob,carol",
+				"ticket":      "SNOW-12345",
+			},
+		},
+	}
+
+	assert.Equal(t, field.ErrorList(nil), policy.Validate())
+	assert.Equal(t, "alice,bob,carol", policy.Spec.Properties["approved-by"])
 }

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
@@ -53,6 +53,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -116,6 +123,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-
@@ -171,6 +188,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -234,6 +258,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-
@@ -288,6 +322,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -351,6 +392,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -31898,6 +31898,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -31961,6 +31968,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-
@@ -32016,6 +32033,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -32079,6 +32103,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-
@@ -32133,6 +32167,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -32196,6 +32237,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-

--- a/config/crds/policies.kyverno.io_policyexceptions.yaml
+++ b/config/crds/policies.kyverno.io_policyexceptions.yaml
@@ -51,6 +51,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -114,6 +121,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-
@@ -169,6 +186,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -232,6 +256,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-
@@ -286,6 +320,13 @@ spec:
                 description: Evaluation mode denotes which controller is in charge
                   of compiling and handling this exception.
                 type: string
+              expiresAt:
+                description: |-
+                  ExpiresAt specifies the time when the policy exception expires.
+                  Once expired, the exception will no longer be applied to incoming requests.
+                  The expected format is RFC3339 date-time (for example "2026-05-01T00:00:00Z").
+                format: date-time
+                type: string
               images:
                 description: |-
                   Images specifies container images to be excluded from policy evaluation.
@@ -349,6 +390,16 @@ spec:
                   - name
                   type: object
                 type: array
+              properties:
+                additionalProperties:
+                  type: string
+                description: |-
+                  Properties is an optional map for additional metadata attached to this exception.
+                  For example:
+                  - reason: why this exception is needed
+                  - ticket: external approval/request identifier
+                  - approved-by: comma-separated approver list
+                type: object
               reportResult:
                 default: skip
                 description: |-

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -2071,6 +2071,38 @@ as a skip result or pass result. Defaults to &ldquo;skip&rdquo;.</p>
 </tr>
 <tr>
 <td>
+<code>expiresAt</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExpiresAt specifies the time when the policy exception expires.
+Once expired, the exception will no longer be applied to incoming requests.
+The expected format is RFC3339 date-time (for example &ldquo;2026-05-01T00:00:00Z&rdquo;).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is an optional map for additional metadata attached to this exception.
+For example:
+- reason: why this exception is needed
+- ticket: external approval/request identifier
+- approved-by: comma-separated approver list</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>evaluationMode</code><br/>
 <em>
 string
@@ -3548,6 +3580,38 @@ string
 <em>(Optional)</em>
 <p>ReportResult indicates whether the policy exception should be reported in the policy report
 as a skip result or pass result. Defaults to &ldquo;skip&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>expiresAt</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExpiresAt specifies the time when the policy exception expires.
+Once expired, the exception will no longer be applied to incoming requests.
+The expected format is RFC3339 date-time (for example &ldquo;2026-05-01T00:00:00Z&rdquo;).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is an optional map for additional metadata attached to this exception.
+For example:
+- reason: why this exception is needed
+- ticket: external approval/request identifier
+- approved-by: comma-separated approver list</p>
 </td>
 </tr>
 <tr>
@@ -6463,6 +6527,38 @@ string
 <em>(Optional)</em>
 <p>ReportResult indicates whether the policy exception should be reported in the policy report
 as a skip result or pass result. Defaults to &ldquo;skip&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>expiresAt</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExpiresAt specifies the time when the policy exception expires.
+Once expired, the exception will no longer be applied to incoming requests.
+The expected format is RFC3339 date-time (for example &ldquo;2026-05-01T00:00:00Z&rdquo;).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is an optional map for additional metadata attached to this exception.
+For example:
+- reason: why this exception is needed
+- ticket: external approval/request identifier
+- approved-by: comma-separated approver list</p>
 </td>
 </tr>
 <tr>
@@ -9443,6 +9539,38 @@ string
 <em>(Optional)</em>
 <p>ReportResult indicates whether the policy exception should be reported in the policy report
 as a skip result or pass result. Defaults to &ldquo;skip&rdquo;.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>expiresAt</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+Kubernetes meta/v1.Time
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ExpiresAt specifies the time when the policy exception expires.
+Once expired, the exception will no longer be applied to incoming requests.
+The expected format is RFC3339 date-time (for example &ldquo;2026-05-01T00:00:00Z&rdquo;).</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>properties</code><br/>
+<em>
+map[string]string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Properties is an optional map for additional metadata attached to this exception.
+For example:
+- reason: why this exception is needed
+- ticket: external approval/request identifier
+- approved-by: comma-separated approver list</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -2522,6 +2522,70 @@ as a skip result or pass result. Defaults to &quot;skip&quot;.</p>
     
     
       <tr>
+        <td><code>expiresAt</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+                <span style="font-family: monospace">meta/v1.Time</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>ExpiresAt specifies the time when the policy exception expires.
+Once expired, the exception will no longer be applied to incoming requests.
+The expected format is RFC3339 date-time (for example &quot;2026-05-01T00:00:00Z&quot;).</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>properties</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>Properties is an optional map for additional metadata attached to this exception.
+For example:</p>
+<ul>
+<li>reason: why this exception is needed</li>
+<li>ticket: external approval/request identifier</li>
+<li>approved-by: comma-separated approver list</li>
+</ul>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
         <td><code>evaluationMode</code>
           
           </br>
@@ -8441,6 +8505,70 @@ These values can be referenced in CEL expressions via <code>exceptions.allowedVa
 
           <p>ReportResult indicates whether the policy exception should be reported in the policy report
 as a skip result or pass result. Defaults to &quot;skip&quot;.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>expiresAt</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#time-v1-meta">
+                <span style="font-family: monospace">meta/v1.Time</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>ExpiresAt specifies the time when the policy exception expires.
+Once expired, the exception will no longer be applied to incoming requests.
+The expected format is RFC3339 date-time (for example &quot;2026-05-01T00:00:00Z&quot;).</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>properties</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">map[string]string</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>Properties is an optional map for additional metadata attached to this exception.
+For example:</p>
+<ul>
+<li>reason: why this exception is needed</li>
+<li>ticket: external approval/request identifier</li>
+<li>approved-by: comma-separated approver list</li>
+</ul>
 
 
           


### PR DESCRIPTION
## Summary
- add `spec.properties` (`map[string]string`) to `PolicyExceptionSpec`
- keep `spec.expiresAt` and document RFC3339 timestamp format
- preserve `IsExpired()` behavior\n- clean `v1`/`v1beta1` wrappers to rely on aliased spec types
- regenerate deepcopy/CRD/docs artifacts
- add tests for `IsExpired` and `properties`

## Notes
This supersedes #40, which could not be updated due lack of push permissions to its original head fork branch.

Relates to https://github.com/kyverno/kyverno/issues/14491.