### PR TITLE
feat: add useServerSideApply to MutatingPolicy evaluation configuration

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/mutating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy.go
@@ -252,6 +252,14 @@ type MutatingPolicyEvaluationConfiguration struct {
 	// +optional
 	// +kubebuilder:default=true
 	SkipBackgroundRequests *bool `json:"skipBackgroundRequests,omitempty"`
+
+	// UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+	// which allows setting atomic fields (for example a container's args or a projected volume)
+	// that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+	// replaced as a whole, so any field the object owner set but the patch does not is dropped.
+	// The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+	// +optional
+	UseServerSideApply bool `json:"useServerSideApply,omitempty"`
 }
 
 type MutatingPolicyAutogenConfiguration struct {

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -125,6 +125,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -1142,6 +1150,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -2324,6 +2340,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -3341,6 +3365,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -4522,6 +4554,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -5539,6 +5579,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -125,6 +125,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -1142,6 +1150,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -2323,6 +2339,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -3340,6 +3364,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -10941,6 +10941,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -11958,6 +11966,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -13140,6 +13156,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -14157,6 +14181,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -15338,6 +15370,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -16355,6 +16395,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -24790,6 +24838,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -25807,6 +25863,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -26988,6 +27052,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -28005,6 +28077,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:

--- a/config/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -123,6 +123,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -1140,6 +1148,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -2322,6 +2338,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -3339,6 +3363,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -4520,6 +4552,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -5537,6 +5577,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:

--- a/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -123,6 +123,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -1140,6 +1148,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:
@@ -2321,6 +2337,14 @@ spec:
                       SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                       The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
                     type: boolean
+                  useServerSideApply:
+                    description: |-
+                      UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                      which allows setting atomic fields (for example a container's args or a projected volume)
+                      that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                      replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                      The default is false, which keeps parity with a native MutatingAdmissionPolicy.
+                    type: boolean
                 type: object
               failurePolicy:
                 description: |-
@@ -3338,6 +3362,14 @@ spec:
                                   description: |-
                                     SkipBackgroundRequests bypasses admission requests that are sent by the background controller.
                                     The default value is set to "true", it must be set to "false" to apply mutateExisting rules to those requests.
+                                  type: boolean
+                                useServerSideApply:
+                                  description: |-
+                                    UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+                                    which allows setting atomic fields (for example a container's args or a projected volume)
+                                    that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+                                    replaced as a whole, so any field the object owner set but the patch does not is dropped.
+                                    The default is false, which keeps parity with a native MutatingAdmissionPolicy.
                                   type: boolean
                               type: object
                             failurePolicy:

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -6158,6 +6158,22 @@ bool
 The default value is set to &ldquo;true&rdquo;, it must be set to &ldquo;false&rdquo; to apply mutateExisting rules to those requests.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>useServerSideApply</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+which allows setting atomic fields (for example a container&rsquo;s args or a projected volume)
+that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+replaced as a whole, so any field the object owner set but the patch does not is dropped.
+The default is false, which keeps parity with a native MutatingAdmissionPolicy.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <hr />

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -7803,6 +7803,37 @@ The default value is set to &quot;true&quot;, it must be set to &quot;false&quot
       </tr>
     
   
+    
+    
+      <tr>
+        <td><code>useServerSideApply</code>
+          
+          </br>
+
+          
+          
+            
+              <span style="font-family: monospace">bool</span>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>UseServerSideApply applies ApplyConfiguration patches with Server-Side Apply semantics,
+which allows setting atomic fields (for example a container's args or a projected volume)
+that the default MutatingAdmissionPolicy behaviour rejects. When true, an atomic value is
+replaced as a whole, so any field the object owner set but the patch does not is dropped.
+The default is false, which keeps parity with a native MutatingAdmissionPolicy.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
 
 
       </tbody>


### PR DESCRIPTION
Adds a `useServerSideApply` field to `MutatingPolicyEvaluationConfiguration`.

This is the API side of the fix for kyverno/kyverno#15094. A MutatingPolicy using ApplyConfiguration currently can't set atomic fields (container args, env valueFrom.fieldRef, projected volumes) because the upstream MutatingAdmissionPolicy patcher rejects atomic mutations. Removing that guard unconditionally would cause silent data loss (an atomic value is replaced as a whole, dropping fields the owner set), so this makes it opt-in.

When `useServerSideApply: true`, the mpol engine applies the patch with Server-Side Apply semantics and allows atomic mutations. Default is false, which keeps parity with a native MutatingAdmissionPolicy.

The engine-side change that reads this field lands in kyverno/kyverno (follow-up to #16509).

Generated CRDs, helm CRDs, and docs updated via `make codegen`.