### PR TITLE
feat: add target match conditions to mutating policies

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/mutating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy.go
@@ -45,8 +45,9 @@ func (status *MutatingPolicyStatus) GetConditionStatus() *ConditionStatus {
 
 // MutatingPolicySpec is the specification of the desired behavior of the MutatingPolicy.
 type MutatingPolicySpec struct {
-	// MatchConstraints specifies what resources this policy is designed to evaluate.
+	// MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 	// The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+	// Trigger constraints and MatchConditions are evaluated before Variables.
 	// Required.
 	MatchConstraints *admissionregistrationv1.MatchResources `json:"matchConstraints,omitempty"`
 
@@ -100,9 +101,19 @@ type MutatingPolicySpec struct {
 	// +optional
 	AutogenConfiguration *MutatingPolicyAutogenConfiguration `json:"autogen,omitempty"`
 
-	// TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.
+	// TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.
 	// +optional
 	TargetMatchConstraints *TargetMatchConstraints `json:"targetMatchConstraints,omitempty"`
+
+	// TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+	// Target match conditions are evaluated after variables and target resolution. They can reference
+	// variables and use Object to refer to the target resource.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=name
+	// +optional
+	TargetMatchConditions []admissionregistrationv1.MatchCondition `json:"targetMatchConditions,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 
 	// mutations contain operations to perform on matching objects.
 	// mutations may not be empty; a minimum of one mutation is required.
@@ -253,10 +264,13 @@ type MAPGenerationConfiguration struct {
 }
 
 type TargetMatchConstraints struct {
+	// Expression resolves one target object or a list of target objects. The expression can use
+	// variables computed from the trigger request.
 	// +optional
 	Expression string `json:"expression,omitempty"`
 
-	// TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.
+	// MatchResources constrains target resources and supplies their API route. When Expression is
+	// set, these rules still determine whether a target uses a subresource endpoint.
 	// +optional
 	admissionregistrationv1.MatchResources `json:",inline"`
 }

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -1212,6 +1212,11 @@ func (in *MutatingPolicySpec) DeepCopyInto(out *MutatingPolicySpec) {
 		*out = new(TargetMatchConstraints)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TargetMatchConditions != nil {
+		in, out := &in.TargetMatchConditions, &out.TargetMatchConditions
+		*out = make([]admissionregistrationv1.MatchCondition, len(*in))
+		copy(*out, *in)
+	}
 	if in.Mutations != nil {
 		in, out := &in.Mutations, &out.Mutations
 		*out = make([]admissionregistrationv1alpha1.Mutation, len(*in))

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -190,8 +190,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -670,9 +671,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -757,6 +803,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -1203,8 +1252,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -1711,9 +1761,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -1799,6 +1895,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -2377,8 +2476,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -2857,9 +2957,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -2944,6 +3089,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -3390,8 +3538,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -3898,9 +4047,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -3986,6 +4181,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -4563,8 +4761,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -5043,9 +5242,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -5130,6 +5374,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -5576,8 +5823,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -6084,9 +6332,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -6172,6 +6466,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -190,8 +190,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -670,9 +671,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -757,6 +803,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -1203,8 +1252,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -1711,9 +1761,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -1799,6 +1895,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -2376,8 +2475,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -2856,9 +2956,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -2943,6 +3088,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -3389,8 +3537,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -3897,9 +4046,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -3985,6 +4180,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -10832,8 +10832,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -11312,9 +11313,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -11399,6 +11445,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -11845,8 +11894,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -12353,9 +12403,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -12441,6 +12537,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -13019,8 +13118,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -13499,9 +13599,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -13586,6 +13731,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -14032,8 +14180,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -14540,9 +14689,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -14628,6 +14823,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -15205,8 +15403,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -15685,9 +15884,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -15772,6 +16016,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -16218,8 +16465,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -16726,9 +16974,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -16814,6 +17108,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -24529,8 +24826,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -25009,9 +25307,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -25096,6 +25439,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -25542,8 +25888,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -26050,9 +26397,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -26138,6 +26531,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -26715,8 +27111,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -27195,9 +27592,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -27282,6 +27724,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -27728,8 +28173,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -28236,9 +28682,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -28324,6 +28816,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-

--- a/config/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -188,8 +188,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -668,9 +669,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -755,6 +801,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -1201,8 +1250,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -1709,9 +1759,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -1797,6 +1893,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -2375,8 +2474,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -2855,9 +2955,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -2942,6 +3087,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -3388,8 +3536,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -3896,9 +4045,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -3984,6 +4179,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -4561,8 +4759,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -5041,9 +5240,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -5128,6 +5372,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -5574,8 +5821,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -6082,9 +6330,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -6170,6 +6464,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-

--- a/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -188,8 +188,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -668,9 +669,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -755,6 +801,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -1201,8 +1250,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -1709,9 +1759,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -1797,6 +1893,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-
@@ -2374,8 +2473,9 @@ spec:
                 x-kubernetes-list-type: map
               matchConstraints:
                 description: |-
-                  MatchConstraints specifies what resources this policy is designed to evaluate.
+                  MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                  Trigger constraints and MatchConditions are evaluated before Variables.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -2854,9 +2954,54 @@ spec:
                   reinvoked when mutations change the object after this mutation is invoked.
                   Required.
                 type: string
+              targetMatchConditions:
+                description: |-
+                  TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                  Target match conditions are evaluated after variables and target resolution. They can reference
+                  variables and use Object to refer to the target resource.
+                items:
+                  description: MatchCondition represents a condition which must by
+                    fulfilled for a request to be sent to a webhook.
+                  properties:
+                    expression:
+                      description: |-
+                        Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                        CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                        'object' - The object from the incoming request. The value is null for DELETE requests.
+                        'oldObject' - The existing object. The value is null for CREATE requests.
+                        'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                        'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                          See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                        'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                          request resource.
+                        Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                        Required.
+                      type: string
+                    name:
+                      description: |-
+                        Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                        as well as providing an identifier for logging purposes. A good name should be descriptive of
+                        the associated expression.
+                        Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                        must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                        '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                        optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                        Required.
+                      type: string
+                  required:
+                  - expression
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
               targetMatchConstraints:
-                description: TargetMatchConstraints specifies what target mutation
-                  resources this policy is designed to evaluate.
+                description: TargetMatchConstraints resolves the resources to mutate
+                  after Variables are evaluated.
                 properties:
                   excludeResourceRules:
                     description: |-
@@ -2941,6 +3086,9 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   expression:
+                    description: |-
+                      Expression resolves one target object or a list of target objects. The expression can use
+                      variables computed from the trigger request.
                     type: string
                   matchPolicy:
                     description: |-
@@ -3387,8 +3535,9 @@ spec:
                               x-kubernetes-list-type: map
                             matchConstraints:
                               description: |-
-                                MatchConstraints specifies what resources this policy is designed to evaluate.
+                                MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
+                                Trigger constraints and MatchConditions are evaluated before Variables.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -3895,9 +4044,55 @@ spec:
                                 reinvoked when mutations change the object after this mutation is invoked.
                                 Required.
                               type: string
+                            targetMatchConditions:
+                              description: |-
+                                TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+                                Target match conditions are evaluated after variables and target resolution. They can reference
+                                variables and use Object to refer to the target resource.
+                              items:
+                                description: MatchCondition represents a condition
+                                  which must by fulfilled for a request to be sent
+                                  to a webhook.
+                                properties:
+                                  expression:
+                                    description: |-
+                                      Expression represents the expression which will be evaluated by CEL. Must evaluate to bool.
+                                      CEL expressions have access to the contents of the AdmissionRequest and Authorizer, organized into CEL variables:
+
+                                      'object' - The object from the incoming request. The value is null for DELETE requests.
+                                      'oldObject' - The existing object. The value is null for CREATE requests.
+                                      'request' - Attributes of the admission request(/pkg/apis/admission/types.go#AdmissionRequest).
+                                      'authorizer' - A CEL Authorizer. May be used to perform authorization checks for the principal (user or service account) of the request.
+                                        See https://pkg.go.dev/k8s.io/apiserver/pkg/cel/library#Authz
+                                      'authorizer.requestResource' - A CEL ResourceCheck constructed from the 'authorizer' and configured with the
+                                        request resource.
+                                      Documentation on CEL: https://kubernetes.io/docs/reference/using-api/cel/
+
+                                      Required.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name is an identifier for this match condition, used for strategic merging of MatchConditions,
+                                      as well as providing an identifier for logging purposes. A good name should be descriptive of
+                                      the associated expression.
+                                      Name must be a qualified name consisting of alphanumeric characters, '-', '_' or '.', and
+                                      must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or
+                                      '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an
+                                      optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')
+
+                                      Required.
+                                    type: string
+                                required:
+                                - expression
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
                             targetMatchConstraints:
-                              description: TargetMatchConstraints specifies what target
-                                mutation resources this policy is designed to evaluate.
+                              description: TargetMatchConstraints resolves the resources
+                                to mutate after Variables are evaluated.
                               properties:
                                 excludeResourceRules:
                                   description: |-
@@ -3983,6 +4178,9 @@ spec:
                                   type: array
                                   x-kubernetes-list-type: atomic
                                 expression:
+                                  description: |-
+                                    Expression resolves one target object or a list of target objects. The expression can use
+                                    variables computed from the trigger request.
                                   type: string
                                 matchPolicy:
                                   description: |-

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -791,8 +791,9 @@ Kubernetes admissionregistration/v1.MatchResources
 </em>
 </td>
 <td>
-<p>MatchConstraints specifies what resources this policy is designed to evaluate.
+<p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 </td>
 </tr>
@@ -882,7 +883,23 @@ TargetMatchConstraints
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+<p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetMatchConditions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.MatchCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 </td>
 </tr>
 <tr>
@@ -1520,8 +1537,9 @@ Kubernetes admissionregistration/v1.MatchResources
 </em>
 </td>
 <td>
-<p>MatchConstraints specifies what resources this policy is designed to evaluate.
+<p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 </td>
 </tr>
@@ -1611,7 +1629,23 @@ TargetMatchConstraints
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+<p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetMatchConditions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.MatchCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 </td>
 </tr>
 <tr>
@@ -3319,8 +3353,9 @@ Kubernetes admissionregistration/v1.MatchResources
 </em>
 </td>
 <td>
-<p>MatchConstraints specifies what resources this policy is designed to evaluate.
+<p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 </td>
 </tr>
@@ -3410,7 +3445,23 @@ TargetMatchConstraints
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+<p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetMatchConditions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.MatchCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 </td>
 </tr>
 <tr>
@@ -6098,8 +6149,9 @@ Kubernetes admissionregistration/v1.MatchResources
 </em>
 </td>
 <td>
-<p>MatchConstraints specifies what resources this policy is designed to evaluate.
+<p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 </td>
 </tr>
@@ -6189,7 +6241,23 @@ TargetMatchConstraints
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+<p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetMatchConditions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.MatchCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 </td>
 </tr>
 <tr>
@@ -7018,6 +7086,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
+<p>Expression resolves one target object or a list of target objects. The expression can use
+variables computed from the trigger request.</p>
 </td>
 </tr>
 <tr>
@@ -7034,7 +7104,8 @@ Kubernetes admissionregistration/v1.MatchResources
 (Members of <code>MatchResources</code> are embedded into this type.)
 </p>
 <em>(Optional)</em>
-<p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+<p>MatchResources constrains target resources and supplies their API route. When Expression is
+set, these rules still determine whether a target uses a subresource endpoint.</p>
 </td>
 </tr>
 </tbody>
@@ -8319,8 +8390,9 @@ Kubernetes admissionregistration/v1.MatchResources
 </em>
 </td>
 <td>
-<p>MatchConstraints specifies what resources this policy is designed to evaluate.
+<p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 </td>
 </tr>
@@ -8410,7 +8482,23 @@ TargetMatchConstraints
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+<p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetMatchConditions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.MatchCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 </td>
 </tr>
 <tr>
@@ -9048,8 +9136,9 @@ Kubernetes admissionregistration/v1.MatchResources
 </em>
 </td>
 <td>
-<p>MatchConstraints specifies what resources this policy is designed to evaluate.
+<p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 </td>
 </tr>
@@ -9139,7 +9228,23 @@ TargetMatchConstraints
 </td>
 <td>
 <em>(Optional)</em>
-<p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+<p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>targetMatchConditions</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.MatchCondition
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -1837,8 +1837,9 @@ image verification functions</p>
         <td>
           
 
-          <p>MatchConstraints specifies what resources this policy is designed to evaluate.
+          <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 
 
@@ -2008,7 +2009,38 @@ Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
         <td>
           
 
-          <p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+          <p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>targetMatchConditions</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+                <span style="font-family: monospace">[]admissionregistration/v1.MatchCondition</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 
 
           
@@ -7739,8 +7771,9 @@ Optional. Default value is &quot;Kubernetes&quot;.</p>
         <td>
           
 
-          <p>MatchConstraints specifies what resources this policy is designed to evaluate.
+          <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
+Trigger constraints and MatchConditions are evaluated before Variables.
 Required.</p>
 
 
@@ -7910,7 +7943,38 @@ Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
         <td>
           
 
-          <p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+          <p>TargetMatchConstraints resolves the resources to mutate after Variables are evaluated.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>targetMatchConditions</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#matchcondition-v1-admissionregistration">
+                <span style="font-family: monospace">[]admissionregistration/v1.MatchCondition</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>TargetMatchConditions is a list of conditions that must be met for a resolved target resource.
+Target match conditions are evaluated after variables and target resolution. They can reference
+variables and use Object to refer to the target resource.</p>
 
 
           
@@ -9486,7 +9550,9 @@ Optional. Defaults to &quot;false&quot; if not specified.</p>
         <td>
           
 
-          
+          <p>Expression resolves one target object or a list of target objects. The expression can use
+variables computed from the trigger request.</p>
+
 
           
 
@@ -9516,7 +9582,8 @@ Optional. Defaults to &quot;false&quot; if not specified.</p>
             <p>(Members of <code>MatchResources</code> are embedded into this type.)</p>
           
 
-          <p>TargetMatchConstraints specifies what target mutation resources this policy is designed to evaluate.</p>
+          <p>MatchResources constrains target resources and supplies their API route. When Expression is
+set, these rules still determine whether a target uses a subresource endpoint.</p>
 
 
           


### PR DESCRIPTION
## Summary

- add `targetMatchConditions` to `MutatingPolicySpec`
- document trigger and target evaluation ordering, including variable visibility
- document target subresource routing
- regenerate deepcopy code, CRDs, Helm CRDs, and API reference docs

This is the API portion of kyverno/kyverno#16612. The Kyverno implementation will consume this field after the API dependency is updated.

## Validation

- `go test ./api/policies.kyverno.io/v1alpha1 ./api/policies.kyverno.io/v1beta1`
- verified `make codegen` is idempotent