### PR TITLE
docs: align match condition variable semantics with implementation

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/mutating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy.go
@@ -47,7 +47,7 @@ func (status *MutatingPolicyStatus) GetConditionStatus() *ConditionStatus {
 type MutatingPolicySpec struct {
 	// MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 	// The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-	// Trigger constraints and MatchConditions are evaluated before Variables.
+	// Trigger constraints and MatchConditions are evaluated before target resolution.
 	// Required.
 	MatchConstraints *admissionregistrationv1.MatchResources `json:"matchConstraints,omitempty"`
 
@@ -85,8 +85,11 @@ type MutatingPolicySpec struct {
 
 	// Variables contain definitions of variables that can be used in composition of other expressions.
 	// Each variable is defined as a named CEL expression.
-	// The variables defined here will be available under `variables` in other expressions of the policy
-	// except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+	// The variables defined here will be available under `variables` in other expressions of the policy,
+	// including MatchConditions where they are evaluated lazily on first reference.
+	// Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+	// conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+	// reference variables in MatchConditions.
 	//
 	// The expression of a variable can refer to other variables defined earlier in the list but not those after.
 	// Thus, Variables must be sorted by the order of first appearance and acyclic.

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -206,7 +206,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -1072,8 +1072,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -1282,7 +1285,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -2181,8 +2184,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -2520,7 +2526,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -3386,8 +3392,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -3596,7 +3605,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -4495,8 +4504,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -4833,7 +4845,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -5699,8 +5711,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -5909,7 +5924,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -6808,8 +6823,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -206,7 +206,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -1072,8 +1072,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -1282,7 +1285,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -2181,8 +2184,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -2519,7 +2525,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -3385,8 +3391,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -3595,7 +3604,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -4494,8 +4503,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -11022,7 +11022,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -11888,8 +11888,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -12098,7 +12101,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -12997,8 +13000,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -13336,7 +13342,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -14202,8 +14208,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -14412,7 +14421,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -15311,8 +15320,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -15649,7 +15661,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -16515,8 +16527,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -16725,7 +16740,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -17624,8 +17639,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -25216,7 +25234,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -26082,8 +26100,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -26292,7 +26313,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -27191,8 +27212,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -27529,7 +27553,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -28395,8 +28419,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -28605,7 +28632,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -29504,8 +29531,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.

--- a/config/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -204,7 +204,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -1070,8 +1070,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -1280,7 +1283,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -2179,8 +2182,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -2518,7 +2524,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -3384,8 +3390,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -3594,7 +3603,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -4493,8 +4502,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -4831,7 +4843,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -5697,8 +5709,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -5907,7 +5922,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -6806,8 +6821,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.

--- a/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -204,7 +204,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -1070,8 +1070,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -1280,7 +1283,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -2179,8 +2182,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -2517,7 +2523,7 @@ spec:
                 description: |-
                   MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                   The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                  Trigger constraints and MatchConditions are evaluated before Variables.
+                  Trigger constraints and MatchConditions are evaluated before target resolution.
                   Required.
                 properties:
                   excludeResourceRules:
@@ -3383,8 +3389,11 @@ spec:
                 description: |-
                   Variables contain definitions of variables that can be used in composition of other expressions.
                   Each variable is defined as a named CEL expression.
-                  The variables defined here will be available under `variables` in other expressions of the policy
-                  except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                  The variables defined here will be available under `variables` in other expressions of the policy,
+                  including MatchConditions where they are evaluated lazily on first reference.
+                  Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                  conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                  reference variables in MatchConditions.
 
                   The expression of a variable can refer to other variables defined earlier in the list but not those after.
                   Thus, Variables must be sorted by the order of first appearance and acyclic.
@@ -3593,7 +3602,7 @@ spec:
                               description: |-
                                 MatchConstraints specifies the trigger resources this policy is designed to evaluate.
                                 The AdmissionPolicy cares about a request if it matches _all_ Constraints.
-                                Trigger constraints and MatchConditions are evaluated before Variables.
+                                Trigger constraints and MatchConditions are evaluated before target resolution.
                                 Required.
                               properties:
                                 excludeResourceRules:
@@ -4492,8 +4501,11 @@ spec:
                               description: |-
                                 Variables contain definitions of variables that can be used in composition of other expressions.
                                 Each variable is defined as a named CEL expression.
-                                The variables defined here will be available under `variables` in other expressions of the policy
-                                except MatchConditions because MatchConditions are evaluated before the rest of the policy.
+                                The variables defined here will be available under `variables` in other expressions of the policy,
+                                including MatchConditions where they are evaluated lazily on first reference.
+                                Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+                                conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+                                reference variables in MatchConditions.
 
                                 The expression of a variable can refer to other variables defined earlier in the list but not those after.
                                 Thus, Variables must be sorted by the order of first appearance and acyclic.

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -811,7 +811,7 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 </td>
 </tr>
@@ -870,8 +870,11 @@ There are a maximum of 64 match conditions allowed.</p>
 <em>(Optional)</em>
 <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 </td>
@@ -1557,7 +1560,7 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 </td>
 </tr>
@@ -1616,8 +1619,11 @@ There are a maximum of 64 match conditions allowed.</p>
 <em>(Optional)</em>
 <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 </td>
@@ -3409,7 +3415,7 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 </td>
 </tr>
@@ -3468,8 +3474,11 @@ There are a maximum of 64 match conditions allowed.</p>
 <em>(Optional)</em>
 <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 </td>
@@ -6265,7 +6274,7 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 </td>
 </tr>
@@ -6324,8 +6333,11 @@ There are a maximum of 64 match conditions allowed.</p>
 <em>(Optional)</em>
 <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 </td>
@@ -8524,7 +8536,7 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 </td>
 </tr>
@@ -8583,8 +8595,11 @@ There are a maximum of 64 match conditions allowed.</p>
 <em>(Optional)</em>
 <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 </td>
@@ -9270,7 +9285,7 @@ Kubernetes admissionregistration/v1.MatchResources
 <td>
 <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 </td>
 </tr>
@@ -9329,8 +9344,11 @@ There are a maximum of 64 match conditions allowed.</p>
 <em>(Optional)</em>
 <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 </td>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -1872,7 +1872,7 @@ image verification functions</p>
 
           <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 
 
@@ -1981,8 +1981,11 @@ There are a maximum of 64 match conditions allowed.</p>
 
           <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 
@@ -7926,7 +7929,7 @@ The default is false, which keeps parity with a native MutatingAdmissionPolicy.<
 
           <p>MatchConstraints specifies the trigger resources this policy is designed to evaluate.
 The AdmissionPolicy cares about a request if it matches <em>all</em> Constraints.
-Trigger constraints and MatchConditions are evaluated before Variables.
+Trigger constraints and MatchConditions are evaluated before target resolution.
 Required.</p>
 
 
@@ -8035,8 +8038,11 @@ There are a maximum of 64 match conditions allowed.</p>
 
           <p>Variables contain definitions of variables that can be used in composition of other expressions.
 Each variable is defined as a named CEL expression.
-The variables defined here will be available under <code>variables</code> in other expressions of the policy
-except MatchConditions because MatchConditions are evaluated before the rest of the policy.</p>
+The variables defined here will be available under <code>variables</code> in other expressions of the policy,
+including MatchConditions where they are evaluated lazily on first reference.
+Note that a native Kubernetes MutatingAdmissionPolicy does not support variables in match
+conditions; policies that generate a MutatingAdmissionPolicy through autogen should not
+reference variables in MatchConditions.</p>
 <p>The expression of a variable can refer to other variables defined earlier in the list but not those after.
 Thus, Variables must be sorted by the order of first appearance and acyclic.</p>
 


### PR DESCRIPTION
## Summary

Follow-up to #112, aligning the MutatingPolicy documentation with the implemented evaluation semantics in kyverno/kyverno#16614.

The Kyverno engine keeps variables lazily visible to trigger `matchConditions` for backward compatibility with existing policies (each variable is evaluated at most once, on first reference, and only if referenced). Two documentation statements described a stricter ordering that the implementation does not enforce:

- `MatchConstraints`: "Trigger constraints and MatchConditions are evaluated before Variables" → now "evaluated before target resolution", which is the enforced contract.
- `Variables`: "available … except MatchConditions" → now documents lazy availability in `MatchConditions`, with a caveat that native `MutatingAdmissionPolicy` does not support this, so policies generating a MAP through autogen should not reference variables in match conditions.

The target-phase documentation (`targetMatchConstraints` resolved after variables, `targetMatchConditions` after target resolution) is unchanged and already matches the implementation.

Regenerated CRDs, Helm CRDs, and API reference docs.

## Related

- kyverno/kyverno#16612 (design discussion resolved toward backward-compatible variable visibility)
- kyverno/kyverno#16614 (implementation)

## Validation

- `go test ./api/policies.kyverno.io/v1alpha1 ./api/policies.kyverno.io/v1beta1`
- verified no strict-ordering text remains in generated MutatingPolicy artifacts