### PR TITLE
fix: tighten Generation exclusivity rule and clarify template namespace docs

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/generating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/generating_policy.go
@@ -213,7 +213,7 @@ type OrphanDownstreamOnPolicyDeleteConfiguration struct {
 }
 
 // Generation defines the configuration for the generation of resources.
-// +kubebuilder:validation:XValidation:rule="(has(self.expression) && !has(self.template)) || (!has(self.expression) && has(self.template))",message="exactly one of expression or template must be set"
+// +kubebuilder:validation:XValidation:rule="(has(self.expression) && self.expression != '' && !has(self.template)) || ((!has(self.expression) || self.expression == '') && has(self.template))",message="exactly one of expression or template must be set"
 type Generation struct {
 	// Expression is a CEL expression that takes a list of resources to be generated.
 	// +optional
@@ -239,8 +239,10 @@ const (
 // GenerationTemplate declares generated resources as a YAML document with optional CEL interpolation.
 type GenerationTemplate struct {
 	// Value is a YAML string, single or multi-document, defining the resources to generate.
-	// The namespace of each generated resource is taken from its rendered metadata.namespace,
-	// resources without a namespace are treated as cluster-scoped.
+	// The namespace of each generated resource is taken from its rendered metadata.namespace.
+	// For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+	// For namespaced policies, resources without a namespace default to the policy's namespace,
+	// and any other namespace is rejected.
 	// +kubebuilder:validation:MinLength=1
 	Value string `json:"value"`
 

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -189,8 +189,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -199,8 +201,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -898,8 +900,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -908,8 +912,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -1606,8 +1610,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -1616,8 +1622,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -191,8 +191,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -201,8 +203,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -901,8 +903,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -911,8 +915,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -1864,8 +1864,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -1874,8 +1876,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -2573,8 +2575,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -2583,8 +2587,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -3281,8 +3285,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -3291,8 +3297,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -19196,8 +19202,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -19206,8 +19214,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -19906,8 +19914,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -19916,8 +19926,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:

--- a/config/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -187,8 +187,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -197,8 +199,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -896,8 +898,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -906,8 +910,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -1604,8 +1608,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -1614,8 +1620,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:

--- a/config/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -189,8 +189,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -199,8 +201,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:
@@ -899,8 +901,10 @@ spec:
                         value:
                           description: |-
                             Value is a YAML string, single or multi-document, defining the resources to generate.
-                            The namespace of each generated resource is taken from its rendered metadata.namespace,
-                            resources without a namespace are treated as cluster-scoped.
+                            The namespace of each generated resource is taken from its rendered metadata.namespace.
+                            For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+                            For namespaced policies, resources without a namespace default to the policy's namespace,
+                            and any other namespace is rejected.
                           minLength: 1
                           type: string
                       required:
@@ -909,8 +913,8 @@ spec:
                   type: object
                   x-kubernetes-validations:
                   - message: exactly one of expression or template must be set
-                    rule: (has(self.expression) && !has(self.template)) || (!has(self.expression)
-                      && has(self.template))
+                    rule: (has(self.expression) && self.expression != '' && !has(self.template))
+                      || ((!has(self.expression) || self.expression == '') && has(self.template))
                 minItems: 1
                 type: array
               matchConditions:

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -5242,8 +5242,10 @@ string
 </td>
 <td>
 <p>Value is a YAML string, single or multi-document, defining the resources to generate.
-The namespace of each generated resource is taken from its rendered metadata.namespace,
-resources without a namespace are treated as cluster-scoped.</p>
+The namespace of each generated resource is taken from its rendered metadata.namespace.
+For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+For namespaced policies, resources without a namespace default to the policy&rsquo;s namespace,
+and any other namespace is rejected.</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -5813,8 +5813,10 @@ with optional CEL interpolation.</p>
           
 
           <p>Value is a YAML string, single or multi-document, defining the resources to generate.
-The namespace of each generated resource is taken from its rendered metadata.namespace,
-resources without a namespace are treated as cluster-scoped.</p>
+The namespace of each generated resource is taken from its rendered metadata.namespace.
+For cluster-scoped policies, resources without a namespace are treated as cluster-scoped.
+For namespaced policies, resources without a namespace default to the policy's namespace,
+and any other namespace is rejected.</p>
 
 
           


### PR DESCRIPTION
## Explanation

Follow-up to #115, addressing review comments raised on kyverno/kyverno#16699.

## Proposed Changes

- **Tighten the `generate[]` XValidation rule**: `has(self.expression)` treated an explicitly empty `expression: ""` as set, so it passed CRD validation while Kyverno's compiler rejects it. The rule now requires a non-empty expression for expression mode, and treats an empty string as unset — consistent with compiler/runtime semantics.

  ```
  (has(self.expression) && self.expression != '' && !has(self.template)) ||
  ((!has(self.expression) || self.expression == '') && has(self.template))
  ```

- **Clarify `GenerationTemplate.Value` docs**: the previous description said documents without `metadata.namespace` are treated as cluster-scoped, which is only true for cluster-scoped policies. Namespaced policies default missing namespaces to the policy namespace and reject cross-namespace targets. The field description now states both behaviors.

- Regenerated CRDs, helm chart CRDs, and API docs.

Once merged, kyverno/kyverno#16699 will bump its dependency to pick up the corrected CRDs.