### PR TITLE
feat: add auditAnnotations to MutatingPolicySpec

### DIFF
--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -28,3 +28,14 @@ jobs:
         run:  |
           set -e
           make verify-codegen
+      - name: Create codegen patch
+        if: failure()
+        run: |
+          git diff > codegen.patch
+          echo 'Codegen is out of date. Download the codegen-patch artifact, then run `git apply codegen.patch` and commit the result.' >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload codegen patch
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: codegen-patch
+          path: codegen.patch

--- a/api/policies.kyverno.io/v1alpha1/mutating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/mutating_policy.go
@@ -129,6 +129,14 @@ type MutatingPolicySpec struct {
 	// +optional
 	Mutations []admissionregistrationv1alpha1.Mutation `json:"mutations,omitempty" protobuf:"bytes,4,rep,name=mutations"`
 
+	// AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+	// as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+	// applied successfully. The results of evaluating the expressions are attached to the report result as
+	// properties with the annotation key.
+	// If the expression evaluates to an empty string or null the annotation will not be included.
+	// +optional
+	AuditAnnotations []admissionregistrationv1.AuditAnnotation `json:"auditAnnotations,omitempty"`
+
 	// WebhookConfiguration defines the configuration for the webhook.
 	// +optional
 	WebhookConfiguration *WebhookConfiguration `json:"webhookConfiguration,omitempty"`

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -1262,6 +1262,11 @@ func (in *MutatingPolicySpec) DeepCopyInto(out *MutatingPolicySpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.AuditAnnotations != nil {
+		in, out := &in.AuditAnnotations, &out.AuditAnnotations
+		*out = make([]admissionregistrationv1.AuditAnnotation, len(*in))
+		copy(*out, *in)
+	}
 	if in.WebhookConfiguration != nil {
 		in, out := &in.WebhookConfiguration, &out.WebhookConfiguration
 		*out = new(WebhookConfiguration)

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -52,6 +52,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -1129,6 +1181,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -2372,6 +2476,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -3449,6 +3605,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -4691,6 +4899,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -5768,6 +6028,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -52,6 +52,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -1129,6 +1181,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -2371,6 +2475,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -3448,6 +3604,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/config/crds.yaml
+++ b/config/crds.yaml
@@ -11003,6 +11003,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -12080,6 +12132,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -13323,6 +13427,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -14400,6 +14556,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -15642,6 +15850,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -16719,6 +16979,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -25305,6 +25617,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -26382,6 +26746,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -27624,6 +28040,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -28701,6 +29169,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/config/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -50,6 +50,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -1127,6 +1179,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -2370,6 +2474,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -3447,6 +3603,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -4689,6 +4897,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -5766,6 +6026,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/config/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -50,6 +50,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -1127,6 +1179,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.
@@ -2369,6 +2473,58 @@ spec:
             description: MutatingPolicySpec is the specification of the desired behavior
               of the MutatingPolicy.
             properties:
+              auditAnnotations:
+                description: |-
+                  AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                  as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                  applied successfully. The results of evaluating the expressions are attached to the report result as
+                  properties with the annotation key.
+                  If the expression evaluates to an empty string or null the annotation will not be included.
+                items:
+                  description: AuditAnnotation describes how to produce an audit annotation
+                    for an API request.
+                  properties:
+                    key:
+                      description: |-
+                        key specifies the audit annotation key. The audit annotation keys of
+                        a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                        name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                        The key is combined with the resource name of the
+                        ValidatingAdmissionPolicy to construct an audit annotation key:
+                        "{ValidatingAdmissionPolicy name}/{key}".
+
+                        If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                        and the same audit annotation key, the annotation key will be identical.
+                        In this case, the first annotation written with the key will be included
+                        in the audit event and all subsequent annotations with the same key
+                        will be discarded.
+
+                        Required.
+                      type: string
+                    valueExpression:
+                      description: |-
+                        valueExpression represents the expression which is evaluated by CEL to
+                        produce an audit annotation value. The expression must evaluate to either
+                        a string or null value. If the expression evaluates to a string, the
+                        audit annotation is included with the string value. If the expression
+                        evaluates to null or empty string the audit annotation will be omitted.
+                        The valueExpression may be no longer than 5kb in length.
+                        If the result of the valueExpression is more than 10kb in length, it
+                        will be truncated to 10kb.
+
+                        If multiple ValidatingAdmissionPolicyBinding resources match an
+                        API request, then the valueExpression will be evaluated for
+                        each binding. All unique values produced by the valueExpressions
+                        will be joined together in a comma-separated list.
+
+                        Required.
+                      type: string
+                  required:
+                  - key
+                  - valueExpression
+                  type: object
+                type: array
               autogen:
                 description: AutogenConfiguration defines the configuration for the
                   generation controller.
@@ -3446,6 +3602,58 @@ spec:
                           description: MutatingPolicySpec is the specification of
                             the desired behavior of the MutatingPolicy.
                           properties:
+                            auditAnnotations:
+                              description: |-
+                                AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+                                as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+                                applied successfully. The results of evaluating the expressions are attached to the report result as
+                                properties with the annotation key.
+                                If the expression evaluates to an empty string or null the annotation will not be included.
+                              items:
+                                description: AuditAnnotation describes how to produce
+                                  an audit annotation for an API request.
+                                properties:
+                                  key:
+                                    description: |-
+                                      key specifies the audit annotation key. The audit annotation keys of
+                                      a ValidatingAdmissionPolicy must be unique. The key must be a qualified
+                                      name ([A-Za-z0-9][-A-Za-z0-9_.]*) no more than 63 bytes in length.
+
+                                      The key is combined with the resource name of the
+                                      ValidatingAdmissionPolicy to construct an audit annotation key:
+                                      "{ValidatingAdmissionPolicy name}/{key}".
+
+                                      If an admission webhook uses the same resource name as this ValidatingAdmissionPolicy
+                                      and the same audit annotation key, the annotation key will be identical.
+                                      In this case, the first annotation written with the key will be included
+                                      in the audit event and all subsequent annotations with the same key
+                                      will be discarded.
+
+                                      Required.
+                                    type: string
+                                  valueExpression:
+                                    description: |-
+                                      valueExpression represents the expression which is evaluated by CEL to
+                                      produce an audit annotation value. The expression must evaluate to either
+                                      a string or null value. If the expression evaluates to a string, the
+                                      audit annotation is included with the string value. If the expression
+                                      evaluates to null or empty string the audit annotation will be omitted.
+                                      The valueExpression may be no longer than 5kb in length.
+                                      If the result of the valueExpression is more than 10kb in length, it
+                                      will be truncated to 10kb.
+
+                                      If multiple ValidatingAdmissionPolicyBinding resources match an
+                                      API request, then the valueExpression will be evaluated for
+                                      each binding. All unique values produced by the valueExpressions
+                                      will be joined together in a comma-separated list.
+
+                                      Required.
+                                    type: string
+                                required:
+                                - key
+                                - valueExpression
+                                type: object
+                              type: array
                             autogen:
                               description: AutogenConfiguration defines the configuration
                                 for the generation controller.

--- a/docs/user/crd/index.html
+++ b/docs/user/crd/index.html
@@ -944,6 +944,24 @@ and reinvocation of mutations occurs on a per binding basis.</p>
 </tr>
 <tr>
 <td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>webhookConfiguration</code><br/>
 <em>
 <a href="#policies.kyverno.io/v1alpha1.WebhookConfiguration">
@@ -1689,6 +1707,24 @@ mutations are evaluated in order, and are reinvoked according to
 the reinvocationPolicy.
 The mutations of a policy are invoked for each binding of this policy
 and reinvocation of mutations occurs on a per binding basis.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
 </td>
 </tr>
 <tr>
@@ -3544,6 +3580,24 @@ mutations are evaluated in order, and are reinvoked according to
 the reinvocationPolicy.
 The mutations of a policy are invoked for each binding of this policy
 and reinvocation of mutations occurs on a per binding basis.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
 </td>
 </tr>
 <tr>
@@ -6492,6 +6546,24 @@ and reinvocation of mutations occurs on a per binding basis.</p>
 </tr>
 <tr>
 <td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>webhookConfiguration</code><br/>
 <em>
 <a href="#policies.kyverno.io/v1alpha1.WebhookConfiguration">
@@ -8754,6 +8826,24 @@ and reinvocation of mutations occurs on a per binding basis.</p>
 </tr>
 <tr>
 <td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>webhookConfiguration</code><br/>
 <em>
 <a href="#policies.kyverno.io/v1alpha1.WebhookConfiguration">
@@ -9499,6 +9589,24 @@ mutations are evaluated in order, and are reinvoked according to
 the reinvocationPolicy.
 The mutations of a policy are invoked for each binding of this policy
 and reinvocation of mutations occurs on a per binding basis.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>auditAnnotations</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+[]Kubernetes admissionregistration/v1.AuditAnnotation
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
 </td>
 </tr>
 <tr>

--- a/docs/user/crd/kyverno_cel_policies.v1alpha1.html
+++ b/docs/user/crd/kyverno_cel_policies.v1alpha1.html
@@ -2123,6 +2123,39 @@ and reinvocation of mutations occurs on a per binding basis.</p>
     
     
       <tr>
+        <td><code>auditAnnotations</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+                <span style="font-family: monospace">[]admissionregistration/v1.AuditAnnotation</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
         <td><code>webhookConfiguration</code>
           
           </br>
@@ -8340,6 +8373,39 @@ mutations are evaluated in order, and are reinvoked according to
 the reinvocationPolicy.
 The mutations of a policy are invoked for each binding of this policy
 and reinvocation of mutations occurs on a per binding basis.</p>
+
+
+          
+
+          
+        </td>
+      </tr>
+    
+  
+    
+    
+      <tr>
+        <td><code>auditAnnotations</code>
+          
+          </br>
+
+          
+          
+            
+              <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.35/#auditannotation-v1-admissionregistration">
+                <span style="font-family: monospace">[]admissionregistration/v1.AuditAnnotation</span>
+              </a>
+            
+          
+        </td>
+        <td>
+          
+
+          <p>AuditAnnotations contains CEL expressions which are used to produce audit annotations that are surfaced
+as properties in policy report results. auditAnnotations are evaluated after the mutations have been
+applied successfully. The results of evaluating the expressions are attached to the report result as
+properties with the annotation key.
+If the expression evaluates to an empty string or null the annotation will not be included.</p>
 
 
           


### PR DESCRIPTION
## What this PR does

Adds `AuditAnnotations []admissionregistrationv1.AuditAnnotation` to `MutatingPolicySpec` (v1alpha1, exposed through the v1beta1/v1 aliases).

The field carries CEL expressions that Kyverno evaluates after mutations are applied successfully; the results are surfaced as properties in policy report results (`results[].properties`). It is intentionally **not** projected into generated Kubernetes `MutatingAdmissionPolicy` resources, since native MAP has no equivalent.

```yaml
spec:
  mutations:
  - patchType: ApplyConfiguration
    applyConfiguration:
      expression: >-
        Object{metadata: Object.metadata{labels: {"env": "test"}}}
  auditAnnotations:
  - key: resource-name
    valueExpression: "'cm/' + string(object.metadata.name)"
```

## Why

Migration parity for the legacy ClusterPolicy `spec.rules[].reportProperties` field (cpol mutate → mpol migration, kyverno/kyverno#16504). This mirrors the field already present on `ValidatingPolicySpec`, `ImageValidatingPolicySpec` and — as of #108/kyverno/kyverno#16505 — `GeneratingPolicySpec`.

## Related

- Consumer implementation: kyverno/kyverno PR (linked from kyverno/kyverno#16719)
- Parent tracking issue: kyverno/kyverno#16504
- GeneratingPolicy precedent: kyverno/kyverno#16503 / kyverno/kyverno#16505

## Changes

- `api/policies.kyverno.io/v1alpha1/mutating_policy.go`: new optional `AuditAnnotations` field on `MutatingPolicySpec`
- `api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go`: regenerated (`make deepcopy-gen`)
