### PR TITLE
fix: omit labels/annotations keys when empty

### DIFF
--- a/charts/kyverno-api/templates/_helpers.tpl
+++ b/charts/kyverno-api/templates/_helpers.tpl
@@ -5,9 +5,13 @@
 {{- end -}}
 
 {{- define "kyverno-api.labels" -}}
-{{- tpl (toYaml .Values.labels) . -}}
+{{- with .Values.labels }}
+{{- tpl (toYaml .) $ }}
+{{- end }}
 {{- end -}}
 
 {{- define "kyverno-api.annotations" -}}
-{{- tpl (toYaml .Values.annotations) . -}}
+{{- with .Values.annotations }}
+{{- tpl (toYaml .) $ }}
+{{- end }}
 {{- end -}}

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_deletingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_deletingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: deletingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_generatingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: generatingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_imagevalidatingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: imagevalidatingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_mutatingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: mutatingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespaceddeletingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespaceddeletingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: namespaceddeletingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedgeneratingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: namespacedgeneratingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedimagevalidatingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: namespacedimagevalidatingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedmutatingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: namespacedmutatingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_namespacedvalidatingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: namespacedvalidatingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_policyexceptions.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: policyexceptions.policies.kyverno.io
 spec:
   group: policies.kyverno.io

--- a/charts/kyverno-api/templates/crds/policies.kyverno.io_validatingpolicies.yaml
+++ b/charts/kyverno-api/templates/crds/policies.kyverno.io_validatingpolicies.yaml
@@ -2,10 +2,14 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  {{- with include "kyverno-api.labels" . }}
   labels:
-    {{- include "kyverno-api.labels" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  {{- with include "kyverno-api.annotations" . }}
   annotations:
-    {{- include "kyverno-api.annotations" . | nindent 4 }}
+    {{- . | nindent 4 }}
+  {{- end }}
   name: validatingpolicies.policies.kyverno.io
 spec:
   group: policies.kyverno.io


### PR DESCRIPTION
## Explanation

Some Kyverno CRDs (the policies.kyverno.io ones) were rendering with empty labels: {} and annotations: {} in their YAML. Kubernetes doesn't store empty fields like that, so ArgoCD kept seeing a mismatch between the file and the live cluster and marked the app as permanently out of sync. This is a bug fix, no new behavior added.


## Related issue

Fixes [kyverno/kyverno#16764](https://github.com/kyverno/kyverno/issues/16764)

## Proposed Changes

The labels/annotations helpers in kyverno-api just dumped whatever was in .Values.labels/.Values.annotations straight into YAML, even when empty. An empty map still renders as the string "{}", so it showed up in output instead of nothing.

Fixed by wrapping both helpers in with, so they render nothing when values are empty, same as the crds subchart already does. Also updated all 11 affected CRD templates so the labels:/annotations: key itself gets skipped when there's nothing under it.


## Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [x] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments
This only fixes the empty map rendering as {} bug. The issue also suggests giving these CRDs the same standard app.kubernetes.io labels the crds subchart CRDs get by default.