### PR TITLE
feat: add FailurePolicy to GeneratingPolicySpec and wire GetFailurePolicy

### DIFF
--- a/api/policies.kyverno.io/v1alpha1/generating_policy.go
+++ b/api/policies.kyverno.io/v1alpha1/generating_policy.go
@@ -99,6 +99,13 @@ type GeneratingPolicySpec struct {
 	// Defaults to "false" if not specified.
 	// +optional
 	UseServerSideApply bool `json:"useServerSideApply,omitempty"`
+
+	// FailurePolicy defines how matchCondition CEL evaluation errors are handled.
+	// Allowed values are Ignore or Fail. Defaults to Fail.
+	// - Ignore: a matchCondition evaluation error is treated as no-match, skipping the policy.
+	// - Fail: a matchCondition evaluation error causes the request to be rejected.
+	// +optional
+	FailurePolicy *admissionregistrationv1.FailurePolicyType `json:"failurePolicy,omitempty"`
 }
 
 type GeneratingPolicyEvaluationConfiguration struct {

--- a/api/policies.kyverno.io/v1alpha1/interfaces.go
+++ b/api/policies.kyverno.io/v1alpha1/interfaces.go
@@ -33,6 +33,7 @@ type GeneratingPolicyLike interface {
 	runtime.Object
 	GetSpec() *GeneratingPolicySpec
 	GetStatus() *GeneratingPolicyStatus
+	GetFailurePolicy(bool) admissionregistrationv1.FailurePolicyType
 	GetMatchConstraints() admissionregistrationv1.MatchResources
 	GetMatchConditions() []admissionregistrationv1.MatchCondition
 	GetVariables() []admissionregistrationv1.Variable

--- a/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
+++ b/api/policies.kyverno.io/v1alpha1/zz_generated.deepcopy.go
@@ -581,6 +581,11 @@ func (in *GeneratingPolicySpec) DeepCopyInto(out *GeneratingPolicySpec) {
 		*out = make([]admissionregistrationv1.AuditAnnotation, len(*in))
 		copy(*out, *in)
 	}
+	if in.FailurePolicy != nil {
+		in, out := &in.FailurePolicy, &out.FailurePolicy
+		*out = new(admissionregistrationv1.FailurePolicyType)
+		**out = **in
+	}
 	return
 }
 

--- a/api/policies.kyverno.io/v1beta1/generating_policy.go
+++ b/api/policies.kyverno.io/v1beta1/generating_policy.go
@@ -64,8 +64,14 @@ func (s *GeneratingPolicy) GetMatchConditions() []admissionregistrationv1.MatchC
 	return s.Spec.MatchConditions
 }
 
-func (s *GeneratingPolicy) GetFailurePolicy(bool) admissionregistrationv1.FailurePolicyType {
-	return admissionregistrationv1.Ignore
+func (s *GeneratingPolicy) GetFailurePolicy(forceFailurePolicyIgnore bool) admissionregistrationv1.FailurePolicyType {
+	if forceFailurePolicyIgnore {
+		return admissionregistrationv1.Ignore
+	}
+	if s.Spec.FailurePolicy != nil {
+		return *s.Spec.FailurePolicy
+	}
+	return admissionregistrationv1.Fail
 }
 
 func (s *GeneratingPolicy) GetTimeoutSeconds() *int32 {
@@ -121,8 +127,14 @@ func (s *NamespacedGeneratingPolicy) GetMatchConditions() []admissionregistratio
 	return s.Spec.MatchConditions
 }
 
-func (s *NamespacedGeneratingPolicy) GetFailurePolicy(bool) admissionregistrationv1.FailurePolicyType {
-	return admissionregistrationv1.Ignore
+func (s *NamespacedGeneratingPolicy) GetFailurePolicy(forceFailurePolicyIgnore bool) admissionregistrationv1.FailurePolicyType {
+	if forceFailurePolicyIgnore {
+		return admissionregistrationv1.Ignore
+	}
+	if s.Spec.FailurePolicy != nil {
+		return *s.Spec.FailurePolicy
+	}
+	return admissionregistrationv1.Fail
 }
 
 func (s *NamespacedGeneratingPolicy) GetTimeoutSeconds() *int32 {

--- a/api/policies.kyverno.io/v1beta1/generating_policy_test.go
+++ b/api/policies.kyverno.io/v1beta1/generating_policy_test.go
@@ -69,11 +69,6 @@ func TestGetMatchConditionsGpol(t *testing.T) {
 	assert.Equal(t, res[0].Expression, "true", "expression should be 'true")
 }
 
-func TestGetFailurePolicyGpol(t *testing.T) {
-	res := gpol.GetFailurePolicy(false)
-	assert.Equal(t, res, v1.Ignore, "result should be 'Ignore")
-}
-
 func TestGetWebhookConfigurationGpol(t *testing.T) {
 	gpol := &GeneratingPolicy{
 		Spec: GeneratingPolicySpec{
@@ -391,12 +386,6 @@ func TestNamespacedGeneratingPolicy_GetMatchConditions(t *testing.T) {
 	assert.Equal(t, "true", res[0].Expression, "expression should be 'true'")
 }
 
-func TestNamespacedGeneratingPolicy_GetFailurePolicy(t *testing.T) {
-	policy := &NamespacedGeneratingPolicy{}
-	res := policy.GetFailurePolicy(false)
-	assert.Equal(t, v1.Ignore, res, "result should be 'Ignore'")
-}
-
 func TestNamespacedGeneratingPolicy_GetTimeoutSeconds(t *testing.T) {
 	t.Run("nil webhook configuration", func(t *testing.T) {
 		policy := &NamespacedGeneratingPolicy{
@@ -449,4 +438,96 @@ func TestNamespacedGeneratingPolicy_GetSpec(t *testing.T) {
 	res := policy.GetSpec()
 	assert.NotNil(t, res, "res should not be nil")
 	assert.Equal(t, 1, len(res.Variables), "should have 1 variable")
+}
+
+func TestGetFailurePolicyGpol(t *testing.T) {
+	fail := v1.Fail
+	ignore := v1.Ignore
+
+	t.Run("GeneratingPolicy: defaults to Fail when FailurePolicy is nil", func(t *testing.T) {
+		gpol := &GeneratingPolicy{
+			Spec: GeneratingPolicySpec{},
+		}
+		assert.Equal(t, v1.Fail, gpol.GetFailurePolicy(false))
+	})
+
+	t.Run("GeneratingPolicy: returns Fail when explicitly set", func(t *testing.T) {
+		gpol := &GeneratingPolicy{
+			Spec: GeneratingPolicySpec{
+				FailurePolicy: &fail,
+			},
+		}
+		assert.Equal(t, v1.Fail, gpol.GetFailurePolicy(false))
+	})
+
+	t.Run("GeneratingPolicy: returns Ignore when explicitly set", func(t *testing.T) {
+		gpol := &GeneratingPolicy{
+			Spec: GeneratingPolicySpec{
+				FailurePolicy: &ignore,
+			},
+		}
+		assert.Equal(t, v1.Ignore, gpol.GetFailurePolicy(false))
+	})
+
+	t.Run("GeneratingPolicy: returns Ignore when forceFailurePolicyIgnore=true regardless of Spec", func(t *testing.T) {
+		gpol := &GeneratingPolicy{
+			Spec: GeneratingPolicySpec{
+				FailurePolicy: &fail,
+			},
+		}
+		assert.Equal(t, v1.Ignore, gpol.GetFailurePolicy(true))
+	})
+
+	t.Run("GeneratingPolicy: returns Ignore when forceFailurePolicyIgnore=true and FailurePolicy is nil", func(t *testing.T) {
+		gpol := &GeneratingPolicy{
+			Spec: GeneratingPolicySpec{},
+		}
+		assert.Equal(t, v1.Ignore, gpol.GetFailurePolicy(true))
+	})
+}
+
+func TestGetFailurePolicyNamespacedGpol(t *testing.T) {
+	fail := v1.Fail
+	ignore := v1.Ignore
+
+	t.Run("NamespacedGeneratingPolicy: defaults to Fail when FailurePolicy is nil", func(t *testing.T) {
+		ngpol := &NamespacedGeneratingPolicy{
+			Spec: GeneratingPolicySpec{},
+		}
+		assert.Equal(t, v1.Fail, ngpol.GetFailurePolicy(false))
+	})
+
+	t.Run("NamespacedGeneratingPolicy: returns Fail when explicitly set", func(t *testing.T) {
+		ngpol := &NamespacedGeneratingPolicy{
+			Spec: GeneratingPolicySpec{
+				FailurePolicy: &fail,
+			},
+		}
+		assert.Equal(t, v1.Fail, ngpol.GetFailurePolicy(false))
+	})
+
+	t.Run("NamespacedGeneratingPolicy: returns Ignore when explicitly set", func(t *testing.T) {
+		ngpol := &NamespacedGeneratingPolicy{
+			Spec: GeneratingPolicySpec{
+				FailurePolicy: &ignore,
+			},
+		}
+		assert.Equal(t, v1.Ignore, ngpol.GetFailurePolicy(false))
+	})
+
+	t.Run("NamespacedGeneratingPolicy: returns Ignore when forceFailurePolicyIgnore=true regardless of Spec", func(t *testing.T) {
+		ngpol := &NamespacedGeneratingPolicy{
+			Spec: GeneratingPolicySpec{
+				FailurePolicy: &fail,
+			},
+		}
+		assert.Equal(t, v1.Ignore, ngpol.GetFailurePolicy(true))
+	})
+
+	t.Run("NamespacedGeneratingPolicy: returns Ignore when forceFailurePolicyIgnore=true and FailurePolicy is nil", func(t *testing.T) {
+		ngpol := &NamespacedGeneratingPolicy{
+			Spec: GeneratingPolicySpec{},
+		}
+		assert.Equal(t, v1.Ignore, ngpol.GetFailurePolicy(true))
+	})
 }


### PR DESCRIPTION
## Explanation
This PR adds the `FailurePolicy` field to `GeneratingPolicySpec` and wires `GetFailurePolicy` into the `GeneratingPolicyLike` interface, matching how it's handled for other CEL-based policies (`ValidatingPolicyLike`, `MutatingPolicyLike`, `ImageValidatingPolicyLike`).

Previously:
- `GeneratingPolicySpec` had no `FailurePolicy` field.
- `GeneratingPolicyLike` did not expose `GetFailurePolicy(bool)`.
- The stub implementations for `GeneratingPolicy` and `NamespacedGeneratingPolicy` in `v1beta1` hardcoded a return value of `admissionregistrationv1.Ignore`, ignoring both the spec and the `forceFailurePolicyIgnore` flag.

Changes included:
1. Added `FailurePolicy *admissionregistrationv1.FailurePolicyType` to `GeneratingPolicySpec` (`v1alpha1`).
2. Added `GetFailurePolicy(bool) admissionregistrationv1.FailurePolicyType` to `GeneratingPolicyLike` interface (`v1alpha1`).
3. Fixed `GetFailurePolicy` implementations for `GeneratingPolicy` and `NamespacedGeneratingPolicy` in `v1beta1` to:
   - Return `Ignore` when `forceFailurePolicyIgnore` is `true`.
   - Read `Spec.FailurePolicy` if configured.
   - Default to `Fail` when unset.
4. Ran codegen (`deepcopy-gen`, `register-gen`, `controller-gen`).
5. Added unit tests for default, explicit `Fail`, explicit `Ignore`, and forced `Ignore` cases.

## Related Issue
Related to https://github.com/kyverno/kyverno/issues/16883
Follow-up PR in main repo: https://github.com/kyverno/kyverno/pull/16892

## Checklist
- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have added unit tests for my changes.
- [x] Generated code and CRDs are up to date.
